### PR TITLE
[DOCS] Adds two new sections to the getting started page

### DIFF
--- a/docs/getting-started.MDX
+++ b/docs/getting-started.MDX
@@ -126,7 +126,7 @@ the previous example with `response['items']`.
 You can get documents by using the following code:
 
 ```ruby
-
+client.get(index: 'my_index', id: id)
 ```
 
 
@@ -166,5 +166,5 @@ client.delete(index: 'books', id: 'Ptink4cBmDx329iqhzM2')
 
 
 ```ruby
-
+client.indices.delete(index: 'my_index')
 ```


### PR DESCRIPTION
# Overview

This PR adds two new sections to the getting started page: Getting a document and Deleting an index. This way, the serverless getting started page covers the same operations as the getting started page of the fully-managed client.