### PR TITLE
[DOCS] Autogenerated code + improvements in source code documentation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ Gemfile.lock
 tmp
 *.log
 .env
+doc
+.yardoc

--- a/README.md
+++ b/README.md
@@ -89,12 +89,9 @@ The parameters are:
 | `tracer`           | `Logger`  | An instance of a Logger-compatible object to use as a tracer.                                                                      |
 | `serializer_class` | `Object`  | A specific serializer class to use to serialize JSON.                                                                              |
 | `headers`          | `Hash`    | Custom HTTP Request Headers                                                                                                        |
-
-
-
 ### Using the API
 
-See [APIs](https://github.com/elastic/elasticsearch-serverless-ruby/blob/main/docs/apis.md) for the full list of available endpoints.
+See [APIs](https://github.com/elastic/elasticsearch-serverless-ruby/blob/main/docs/apis.md) for the full list of available endpoints. Check [rubydoc](https://rubydoc.info/gems/elasticsearch-serverless/) for the API reference, or run `yardoc` in the root of the project if you've checked out the code. The API reference documentation will be generated in the `doc` folder.
 
 Once you've instantiated a client with your API key and Elasticsearch endpoint, you can start ingesting documents into Elasticsearch Service. You can use the **Bulk API** for this. This API allows you to index, update and delete several documents in one request. You call the `bulk` API on the client with a body parameter, an Array of hashes that define the action and a document. Here's an example of indexing some classic books into the `books` index:
 

--- a/lib/elasticsearch-serverless.rb
+++ b/lib/elasticsearch-serverless.rb
@@ -27,9 +27,9 @@ module ElasticsearchServerless
 
     # Initializes an Elasticsearch Serverless Client
     #
-    # @param :api_key [String] Base64 String, format used to authenticate with Elasticsearch
-    # @param :url [String] Elasticsearch endpoint
-    # @param :arguments [Hash] Other optional arguments.
+    # @param [String] api_key Base64 String, format used to authenticate with Elasticsearch
+    # @param [String] url Elasticsearch endpoint
+    # @param [Hash] arguments Other optional arguments.
     # @option arguments [Symbol] :adapter A specific adapter for Faraday (e.g. `:patron`)
     # @option arguments [Boolean] :log Use the default logger (disabled by default)
     # @option arguments [Object] :logger An instance of a Logger-compatible object

--- a/lib/elasticsearch-serverless/api/async_search/delete.rb
+++ b/lib/elasticsearch-serverless/api/async_search/delete.rb
@@ -25,7 +25,7 @@ module ElasticsearchServerless
         # Deletes an async search by identifier.
         # If the search is still running, the search request will be cancelled.
         # Otherwise, the saved search results are deleted.
-        # If the Elasticsearch security features are enabled, the deletion of a specific async search is restricted to: the authenticated user that submitted the original search request; users that have the `cancel_task` cluster privilege.
+        # If the Elasticsearch security features are enabled, the deletion of a specific async search is restricted to: the authenticated user that submitted the original search request; users that have the +cancel_task+ cluster privilege.
         #
         # @option arguments [String] :id A unique identifier for the async search. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/async_search/delete.rb
+++ b/lib/elasticsearch-serverless/api/async_search/delete.rb
@@ -22,7 +22,10 @@ module ElasticsearchServerless
   module API
     module AsyncSearch
       module Actions
-        # Deletes an async search by ID. If the search is still running, the search request will be cancelled. Otherwise, the saved search results are deleted.
+        # Deletes an async search by identifier.
+        # If the search is still running, the search request will be cancelled.
+        # Otherwise, the saved search results are deleted.
+        # If the Elasticsearch security features are enabled, the deletion of a specific async search is restricted to: the authenticated user that submitted the original search request; users that have the `cancel_task` cluster privilege.
         #
         # @option arguments [String] :id A unique identifier for the async search. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/async_search/get.rb
+++ b/lib/elasticsearch-serverless/api/async_search/get.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module AsyncSearch
       module Actions
-        # Retrieves the results of a previously submitted async search request given its ID.
+        # Retrieves the results of a previously submitted async search request given its identifier.
+        # If the Elasticsearch security features are enabled, access to the results of a specific async search is restricted to the user or API key that submitted it.
         #
         # @option arguments [String] :id A unique identifier for the async search. (*Required*)
         # @option arguments [Time] :keep_alive Specifies how long the async search should be available in the cluster. When not specified, the +keep_alive+ set with the corresponding submit async request will be used. Otherwise, it is possible to override the value and extend the validity of the request. When this period expires, the search, if still running, is cancelled. If the search is completed, its saved results are deleted.

--- a/lib/elasticsearch-serverless/api/async_search/status.rb
+++ b/lib/elasticsearch-serverless/api/async_search/status.rb
@@ -24,7 +24,7 @@ module ElasticsearchServerless
       module Actions
         # Get async search status
         # Retrieves the status of a previously submitted async search request given its identifier, without retrieving search results.
-        # If the Elasticsearch security features are enabled, use of this API is restricted to the `monitoring_user` role.
+        # If the Elasticsearch security features are enabled, use of this API is restricted to the +monitoring_user+ role.
         #
         # @option arguments [String] :id A unique identifier for the async search. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/async_search/status.rb
+++ b/lib/elasticsearch-serverless/api/async_search/status.rb
@@ -22,7 +22,9 @@ module ElasticsearchServerless
   module API
     module AsyncSearch
       module Actions
-        # Retrieves the status of a previously submitted async search request given its ID.
+        # Get async search status
+        # Retrieves the status of a previously submitted async search request given its identifier, without retrieving search results.
+        # If the Elasticsearch security features are enabled, use of this API is restricted to the `monitoring_user` role.
         #
         # @option arguments [String] :id A unique identifier for the async search. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/async_search/submit.rb
+++ b/lib/elasticsearch-serverless/api/async_search/submit.rb
@@ -26,7 +26,7 @@ module ElasticsearchServerless
         # When the primary sort of the results is an indexed field, shards get sorted based on minimum and maximum value that they hold for that field, hence partial results become available following the sort criteria that was requested.
         # Warning: Async search does not support scroll nor search requests that only include the suggest section.
         # By default, Elasticsearch doesn’t allow you to store an async search response larger than 10Mb and an attempt to do this results in an error.
-        # The maximum allowed size for a stored async search response can be set by changing the `search.max_async_search_response_size` cluster level setting.
+        # The maximum allowed size for a stored async search response can be set by changing the +search.max_async_search_response_size+ cluster level setting.
         #
         # @option arguments [String, Array] :index A comma-separated list of index names to search; use +_all+ or empty string to perform the operation on all indices
         # @option arguments [Time] :wait_for_completion_timeout Blocks and waits until the search is completed up to a certain timeout. When the async search completes within the timeout, the response won’t include the ID as the results are not stored in the cluster. Server default: 1s.

--- a/lib/elasticsearch-serverless/api/async_search/submit.rb
+++ b/lib/elasticsearch-serverless/api/async_search/submit.rb
@@ -22,7 +22,11 @@ module ElasticsearchServerless
   module API
     module AsyncSearch
       module Actions
-        # Executes a search request asynchronously.
+        # Runs a search request asynchronously.
+        # When the primary sort of the results is an indexed field, shards get sorted based on minimum and maximum value that they hold for that field, hence partial results become available following the sort criteria that was requested.
+        # Warning: Async search does not support scroll nor search requests that only include the suggest section.
+        # By default, Elasticsearch doesn’t allow you to store an async search response larger than 10Mb and an attempt to do this results in an error.
+        # The maximum allowed size for a stored async search response can be set by changing the `search.max_async_search_response_size` cluster level setting.
         #
         # @option arguments [String, Array] :index A comma-separated list of index names to search; use +_all+ or empty string to perform the operation on all indices
         # @option arguments [Time] :wait_for_completion_timeout Blocks and waits until the search is completed up to a certain timeout. When the async search completes within the timeout, the response won’t include the ID as the results are not stored in the cluster. Server default: 1s.

--- a/lib/elasticsearch-serverless/api/bulk.rb
+++ b/lib/elasticsearch-serverless/api/bulk.rb
@@ -21,7 +21,8 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Allows to perform multiple index/update/delete operations in a single request.
+      # Performs multiple indexing or delete operations in a single API call.
+      # This reduces overhead and can greatly increase indexing speed.
       #
       # @option arguments [String] :index Name of the data stream, index, or index alias to perform bulk actions on.
       # @option arguments [String] :pipeline ID of the pipeline to use to preprocess incoming documents. If the index has a default ingest pipeline specified, then setting the value to +_none+ disables the default ingest pipeline for this request. If a final pipeline is configured it will always run, regardless of the value of this parameter.

--- a/lib/elasticsearch-serverless/api/cat/aliases.rb
+++ b/lib/elasticsearch-serverless/api/cat/aliases.rb
@@ -22,7 +22,9 @@ module ElasticsearchServerless
   module API
     module Cat
       module Actions
-        # Shows information about currently configured aliases to indices including filter and routing infos.
+        # Retrieves the cluster’s index aliases, including filter and routing information.
+        # The API does not return data stream aliases.
+        # IMPORTANT: cat APIs are only intended for human consumption using the command line or the Kibana console. They are not intended for use by applications. For application consumption, use the aliases API.
         #
         # @option arguments [String, Array<String>] :name A comma-separated list of aliases to retrieve. Supports wildcards (+*+).  To retrieve all aliases, omit this parameter or use +*+ or +_all+.
         # @option arguments [String, Array<String>] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.

--- a/lib/elasticsearch-serverless/api/cat/component_templates.rb
+++ b/lib/elasticsearch-serverless/api/cat/component_templates.rb
@@ -22,7 +22,10 @@ module ElasticsearchServerless
   module API
     module Cat
       module Actions
-        # Returns information about existing component_templates templates.
+        # Returns information about component templates in a cluster.
+        # Component templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.
+        # IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console.
+        # They are not intended for use by applications. For application consumption, use the get component template API.
         #
         # @option arguments [String] :name The name of the component template. Accepts wildcard expressions. If omitted, all component templates are returned.
         # @option arguments [String] :format Specifies the format to return the columnar data in, can be set to +text+, +json+, +cbor+, +yaml+, or +smile+. Server default: text.

--- a/lib/elasticsearch-serverless/api/cat/count.rb
+++ b/lib/elasticsearch-serverless/api/cat/count.rb
@@ -22,7 +22,10 @@ module ElasticsearchServerless
   module API
     module Cat
       module Actions
-        # Provides quick access to the document count of the entire cluster, or individual indices.
+        # Provides quick access to a document count for a data stream, an index, or an entire cluster.
+        # NOTE: The document count only includes live documents, not deleted documents which have not yet been removed by the merge process.
+        # IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console.
+        # They are not intended for use by applications. For application consumption, use the count API.
         #
         # @option arguments [String, Array] :index Comma-separated list of data streams, indices, and aliases used to limit the request. Supports wildcards (+*+). To target all data streams and indices, omit this parameter or use +*+ or +_all+.
         # @option arguments [String] :format Specifies the format to return the columnar data in, can be set to +text+, +json+, +cbor+, +yaml+, or +smile+. Server default: text.

--- a/lib/elasticsearch-serverless/api/cat/indices.rb
+++ b/lib/elasticsearch-serverless/api/cat/indices.rb
@@ -22,7 +22,12 @@ module ElasticsearchServerless
   module API
     module Cat
       module Actions
-        # Returns information about indices: number of primaries and replicas, document counts, disk size, ...
+        # Returns high-level information about indices in a cluster, including backing indices for data streams.
+        # IMPORTANT: cat APIs are only intended for human consumption using the command line or Kibana console.
+        # They are not intended for use by applications. For application consumption, use the get index API.
+        # Use the cat indices API to get the following information for each index in a cluster: shard count; document count; deleted document count; primary store size; total store size of all shards, including shard replicas.
+        # These metrics are retrieved directly from Lucene, which Elasticsearch uses internally to power indexing and search. As a result, all document counts include hidden nested documents.
+        # To get an accurate count of Elasticsearch documents, use the cat count or count APIs.
         #
         # @option arguments [String, Array] :index Comma-separated list of data streams, indices, and aliases used to limit the request. Supports wildcards (+*+). To target all data streams and indices, omit this parameter or use +*+ or +_all+.
         # @option arguments [String] :bytes The unit used to display byte values.

--- a/lib/elasticsearch-serverless/api/cat/ml_data_frame_analytics.rb
+++ b/lib/elasticsearch-serverless/api/cat/ml_data_frame_analytics.rb
@@ -22,7 +22,11 @@ module ElasticsearchServerless
   module API
     module Cat
       module Actions
-        # Gets configuration and usage information about data frame analytics jobs.
+        # Returns configuration and usage information about data frame analytics jobs.
+        #
+        # IMPORTANT: cat APIs are only intended for human consumption using the Kibana
+        # console or command line. They are not intended for use by applications. For
+        # application consumption, use the get data frame analytics jobs statistics API.
         #
         # @option arguments [String] :id The ID of the data frame analytics to fetch
         # @option arguments [Boolean] :allow_no_match Whether to ignore if a wildcard expression matches no configs. (This includes +_all+ string or when no configs have been specified)

--- a/lib/elasticsearch-serverless/api/cat/ml_datafeeds.rb
+++ b/lib/elasticsearch-serverless/api/cat/ml_datafeeds.rb
@@ -22,7 +22,14 @@ module ElasticsearchServerless
   module API
     module Cat
       module Actions
-        # Gets configuration and usage information about datafeeds.
+        # Returns configuration and usage information about datafeeds.
+        # This API returns a maximum of 10,000 datafeeds.
+        # If the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`
+        # cluster privileges to use this API.
+        #
+        # IMPORTANT: cat APIs are only intended for human consumption using the Kibana
+        # console or command line. They are not intended for use by applications. For
+        # application consumption, use the get datafeed statistics API.
         #
         # @option arguments [String] :datafeed_id A numerical character string that uniquely identifies the datafeed.
         # @option arguments [Boolean] :allow_no_match Specifies what to do when the request:  * Contains wildcard expressions and there are no datafeeds that match. * Contains the +_all+ string or no identifiers and there are no matches. * Contains wildcard expressions and there are only partial matches.  If +true+, the API returns an empty datafeeds array when there are no matches and the subset of results when there are partial matches. If +false+, the API returns a 404 status code when there are no matches or only partial matches. Server default: true.

--- a/lib/elasticsearch-serverless/api/cat/ml_datafeeds.rb
+++ b/lib/elasticsearch-serverless/api/cat/ml_datafeeds.rb
@@ -24,7 +24,7 @@ module ElasticsearchServerless
       module Actions
         # Returns configuration and usage information about datafeeds.
         # This API returns a maximum of 10,000 datafeeds.
-        # If the Elasticsearch security features are enabled, you must have `monitor_ml`, `monitor`, `manage_ml`, or `manage`
+        # If the Elasticsearch security features are enabled, you must have +monitor_ml+, +monitor+, +manage_ml+, or +manage+
         # cluster privileges to use this API.
         #
         # IMPORTANT: cat APIs are only intended for human consumption using the Kibana

--- a/lib/elasticsearch-serverless/api/cat/ml_jobs.rb
+++ b/lib/elasticsearch-serverless/api/cat/ml_jobs.rb
@@ -22,7 +22,14 @@ module ElasticsearchServerless
   module API
     module Cat
       module Actions
-        # Gets configuration and usage information about anomaly detection jobs.
+        # Returns configuration and usage information for anomaly detection jobs.
+        # This API returns a maximum of 10,000 jobs.
+        # If the Elasticsearch security features are enabled, you must have `monitor_ml`,
+        # `monitor`, `manage_ml`, or `manage` cluster privileges to use this API.
+        #
+        # IMPORTANT: cat APIs are only intended for human consumption using the Kibana
+        # console or command line. They are not intended for use by applications. For
+        # application consumption, use the get anomaly detection job statistics API.
         #
         # @option arguments [String] :job_id Identifier for the anomaly detection job.
         # @option arguments [Boolean] :allow_no_match Specifies what to do when the request:  * Contains wildcard expressions and there are no jobs that match. * Contains the +_all+ string or no identifiers and there are no matches. * Contains wildcard expressions and there are only partial matches.  If +true+, the API returns an empty jobs array when there are no matches and the subset of results when there are partial matches. If +false+, the API returns a 404 status code when there are no matches or only partial matches. Server default: true.

--- a/lib/elasticsearch-serverless/api/cat/ml_jobs.rb
+++ b/lib/elasticsearch-serverless/api/cat/ml_jobs.rb
@@ -24,8 +24,8 @@ module ElasticsearchServerless
       module Actions
         # Returns configuration and usage information for anomaly detection jobs.
         # This API returns a maximum of 10,000 jobs.
-        # If the Elasticsearch security features are enabled, you must have `monitor_ml`,
-        # `monitor`, `manage_ml`, or `manage` cluster privileges to use this API.
+        # If the Elasticsearch security features are enabled, you must have +monitor_ml+,
+        # +monitor+, +manage_ml+, or +manage+ cluster privileges to use this API.
         #
         # IMPORTANT: cat APIs are only intended for human consumption using the Kibana
         # console or command line. They are not intended for use by applications. For

--- a/lib/elasticsearch-serverless/api/cat/ml_trained_models.rb
+++ b/lib/elasticsearch-serverless/api/cat/ml_trained_models.rb
@@ -22,7 +22,11 @@ module ElasticsearchServerless
   module API
     module Cat
       module Actions
-        # Gets configuration and usage information about inference trained models.
+        # Returns configuration and usage information about inference trained models.
+        #
+        # IMPORTANT: cat APIs are only intended for human consumption using the Kibana
+        # console or command line. They are not intended for use by applications. For
+        # application consumption, use the get trained models statistics API.
         #
         # @option arguments [String] :model_id A unique identifier for the trained model.
         # @option arguments [Boolean] :allow_no_match Specifies what to do when the request: contains wildcard expressions and there are no models that match; contains the +_all+ string or no identifiers and there are no matches; contains wildcard expressions and there are only partial matches. If +true+, the API returns an empty array when there are no matches and the subset of results when there are partial matches. If +false+, the API returns a 404 status code when there are no matches or only partial matches. Server default: true.

--- a/lib/elasticsearch-serverless/api/cat/transforms.rb
+++ b/lib/elasticsearch-serverless/api/cat/transforms.rb
@@ -22,7 +22,11 @@ module ElasticsearchServerless
   module API
     module Cat
       module Actions
-        # Gets configuration and usage information about transforms.
+        # Returns configuration and usage information about transforms.
+        #
+        # IMPORTANT: cat APIs are only intended for human consumption using the Kibana
+        # console or command line. They are not intended for use by applications. For
+        # application consumption, use the get transform statistics API.
         #
         # @option arguments [String] :transform_id A transform identifier or a wildcard expression. If you do not specify one of these options, the API returns information for all transforms.
         # @option arguments [Boolean] :allow_no_match Specifies what to do when the request: contains wildcard expressions and there are no transforms that match; contains the +_all+ string or no identifiers and there are no matches; contains wildcard expressions and there are only partial matches. If +true+, it returns an empty transforms array when there are no matches and the subset of results when there are partial matches. If +false+, the request returns a 404 status code when there are no matches or only partial matches. Server default: true.

--- a/lib/elasticsearch-serverless/api/clear_scroll.rb
+++ b/lib/elasticsearch-serverless/api/clear_scroll.rb
@@ -21,7 +21,7 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Explicitly clears the search context for a scroll.
+      # Clears the search context and results for a scrolling search.
       #
       # @option arguments [String, Array] :scroll_id Comma-separated list of scroll IDs to clear. To clear all scroll IDs, use +_all+.
       # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/close_point_in_time.rb
+++ b/lib/elasticsearch-serverless/api/close_point_in_time.rb
@@ -21,7 +21,7 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Close a point in time
+      # Closes a point-in-time.
       #
       # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body request body

--- a/lib/elasticsearch-serverless/api/cluster/delete_component_template.rb
+++ b/lib/elasticsearch-serverless/api/cluster/delete_component_template.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module Cluster
       module Actions
-        # Deletes a component template
+        # Deletes component templates.
+        # Component templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.
         #
         # @option arguments [String, Array<String>] :name Comma-separated list or wildcard expression of component template names used to limit the request. (*Required*)
         # @option arguments [Time] :master_timeout Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error. Server default: 30s.

--- a/lib/elasticsearch-serverless/api/cluster/get_component_template.rb
+++ b/lib/elasticsearch-serverless/api/cluster/get_component_template.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Cluster
       module Actions
-        # Returns one or more component templates
+        # Retrieves information about component templates.
         #
         # @option arguments [String] :name Comma-separated list of component template names used to limit the request. Wildcard (+*+) expressions are supported.
         # @option arguments [Boolean] :flat_settings If +true+, returns settings in flat format.

--- a/lib/elasticsearch-serverless/api/cluster/put_component_template.rb
+++ b/lib/elasticsearch-serverless/api/cluster/put_component_template.rb
@@ -22,7 +22,21 @@ module ElasticsearchServerless
   module API
     module Cluster
       module Actions
-        # Creates or updates a component template
+        # Creates or updates a component template.
+        # Component templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.
+        #
+        # An index template can be composed of multiple component templates.
+        # To use a component template, specify it in an index template’s `composed_of` list.
+        # Component templates are only applied to new data streams and indices as part of a matching index template.
+        #
+        # Settings and mappings specified directly in the index template or the create index request override any settings or mappings specified in a component template.
+        #
+        # Component templates are only used during index creation.
+        # For data streams, this includes data stream creation and the creation of a stream’s backing indices.
+        # Changes to component templates do not affect existing indices, including a stream’s backing indices.
+        #
+        # You can use C-style `/* *\/` block comments in component templates.
+        # You can include comments anywhere in the request body except before the opening curly bracket.
         #
         # @option arguments [String] :name Name of the component template to create. Elasticsearch includes the following built-in component templates: +logs-mappings+; 'logs-settings+; +metrics-mappings+; +metrics-settings+;+synthetics-mapping+; +synthetics-settings+. Elastic Agent uses these templates to configure backing indices for its data streams. If you use Elastic Agent and want to overwrite one of these templates, set the +version+ for your replacement template higher than the current version. If you don’t use Elastic Agent and want to disable all built-in component and index templates, set +stack.templates.enabled+ to +false+ using the cluster update settings API. (*Required*)
         # @option arguments [Boolean] :create If +true+, this request cannot replace or update existing component templates.

--- a/lib/elasticsearch-serverless/api/cluster/put_component_template.rb
+++ b/lib/elasticsearch-serverless/api/cluster/put_component_template.rb
@@ -26,7 +26,7 @@ module ElasticsearchServerless
         # Component templates are building blocks for constructing index templates that specify index mappings, settings, and aliases.
         #
         # An index template can be composed of multiple component templates.
-        # To use a component template, specify it in an index template’s `composed_of` list.
+        # To use a component template, specify it in an index template’s +composed_of+ list.
         # Component templates are only applied to new data streams and indices as part of a matching index template.
         #
         # Settings and mappings specified directly in the index template or the create index request override any settings or mappings specified in a component template.
@@ -35,7 +35,7 @@ module ElasticsearchServerless
         # For data streams, this includes data stream creation and the creation of a stream’s backing indices.
         # Changes to component templates do not affect existing indices, including a stream’s backing indices.
         #
-        # You can use C-style `/* *\/` block comments in component templates.
+        # You can use C-style +/* *\/+ block comments in component templates.
         # You can include comments anywhere in the request body except before the opening curly bracket.
         #
         # @option arguments [String] :name Name of the component template to create. Elasticsearch includes the following built-in component templates: +logs-mappings+; 'logs-settings+; +metrics-mappings+; +metrics-settings+;+synthetics-mapping+; +synthetics-settings+. Elastic Agent uses these templates to configure backing indices for its data streams. If you use Elastic Agent and want to overwrite one of these templates, set the +version+ for your replacement template higher than the current version. If you don’t use Elastic Agent and want to disable all built-in component and index templates, set +stack.templates.enabled+ to +false+ using the cluster update settings API. (*Required*)

--- a/lib/elasticsearch-serverless/api/create.rb
+++ b/lib/elasticsearch-serverless/api/create.rb
@@ -21,9 +21,8 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Creates a new document in the index.
-      #
-      # Returns a 409 response when a document with a same ID already exists in the index.
+      # Adds a JSON document to the specified data stream or index and makes it searchable.
+      # If the target is an index and the document already exists, the request updates the document and increments its version.
       #
       # @option arguments [String] :id Unique identifier for the document. (*Required*)
       # @option arguments [String] :index Name of the data stream or index to target. If the target doesn’t exist and matches the name or wildcard (+*+) pattern of an index template with a +data_stream+ definition, this request creates the data stream. If the target doesn’t exist and doesn’t match a data stream template, this request creates the index. (*Required*)

--- a/lib/elasticsearch-serverless/api/delete.rb
+++ b/lib/elasticsearch-serverless/api/delete.rb
@@ -21,7 +21,7 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Removes a document from the index.
+      # Removes a JSON document from the specified index.
       #
       # @option arguments [String] :id Unique identifier for the document. (*Required*)
       # @option arguments [String] :index Name of the target index. (*Required*)

--- a/lib/elasticsearch-serverless/api/delete_by_query.rb
+++ b/lib/elasticsearch-serverless/api/delete_by_query.rb
@@ -21,7 +21,7 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Deletes documents matching the provided query.
+      # Deletes documents that match the specified query.
       #
       # @option arguments [String, Array] :index Comma-separated list of data streams, indices, and aliases to search. Supports wildcards (+*+). To search all data streams or indices, omit this parameter or use +*+ or +_all+. (*Required*)
       # @option arguments [Boolean] :allow_no_indices If +false+, the request returns an error if any wildcard expression, index alias, or +_all+ value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request targeting +foo*,bar*+ returns an error if an index starts with +foo+ but no index starts with +bar+. Server default: true.

--- a/lib/elasticsearch-serverless/api/delete_script.rb
+++ b/lib/elasticsearch-serverless/api/delete_script.rb
@@ -21,7 +21,7 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Deletes a script.
+      # Deletes a stored script or search template.
       #
       # @option arguments [String] :id Identifier for the stored script or search template. (*Required*)
       # @option arguments [Time] :master_timeout Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error. Server default: 30s.

--- a/lib/elasticsearch-serverless/api/enrich/get_policy.rb
+++ b/lib/elasticsearch-serverless/api/enrich/get_policy.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Enrich
       module Actions
-        # Gets information about an enrich policy.
+        # Returns information about an enrich policy.
         #
         # @option arguments [String, Array<String>] :name Comma-separated list of enrich policy names used to limit the request. To return information for all enrich policies, omit this parameter.
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/enrich/put_policy.rb
+++ b/lib/elasticsearch-serverless/api/enrich/put_policy.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Enrich
       module Actions
-        # Creates a new enrich policy.
+        # Creates an enrich policy.
         #
         # @option arguments [String] :name Name of the enrich policy to create or update. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/enrich/stats.rb
+++ b/lib/elasticsearch-serverless/api/enrich/stats.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Enrich
       module Actions
-        # Gets enrich coordinator statistics and information about enrich policies that are currently executing.
+        # Returns enrich coordinator statistics and information about enrich policies that are currently executing.
         #
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/lib/elasticsearch-serverless/api/eql/delete.rb
+++ b/lib/elasticsearch-serverless/api/eql/delete.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module Eql
       module Actions
-        # Deletes an async EQL search by ID. If the search is still running, the search request will be cancelled. Otherwise, the saved search results are deleted.
+        # Deletes an async EQL search or a stored synchronous EQL search.
+        # The API also deletes results for the search.
         #
         # @option arguments [String] :id Identifier for the search to delete. A search ID is provided in the EQL search API's response for an async search. A search ID is also provided if the request’s +keep_on_completion+ parameter is +true+. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/eql/get.rb
+++ b/lib/elasticsearch-serverless/api/eql/get.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Eql
       module Actions
-        # Returns async results from previously executed Event Query Language (EQL) search
+        # Returns the current status and available results for an async EQL search or a stored synchronous EQL search.
         #
         # @option arguments [String] :id Identifier for the search. (*Required*)
         # @option arguments [Time] :keep_alive Period for which the search and its results are stored on the cluster. Defaults to the keep_alive value set by the search’s EQL search API request.

--- a/lib/elasticsearch-serverless/api/eql/get_status.rb
+++ b/lib/elasticsearch-serverless/api/eql/get_status.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Eql
       module Actions
-        # Returns the status of a previously submitted async or stored Event Query Language (EQL) search
+        # Returns the current status for an async EQL search or a stored synchronous EQL search without returning results.
         #
         # @option arguments [String] :id Identifier for the search. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/esql/query.rb
+++ b/lib/elasticsearch-serverless/api/esql/query.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Esql
       module Actions
-        # Executes an ESQL request
+        # Executes an ES|QL request
         # This functionality is Experimental and may be changed or removed
         # completely in a future release. Elastic will take a best effort approach
         # to fix any issues, but experimental features are not subject to the

--- a/lib/elasticsearch-serverless/api/exists.rb
+++ b/lib/elasticsearch-serverless/api/exists.rb
@@ -21,7 +21,7 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Returns information about whether a document exists in an index.
+      # Checks if a document in an index exists.
       #
       # @option arguments [String] :id Identifier of the document. (*Required*)
       # @option arguments [String] :index Comma-separated list of data streams, indices, and aliases. Supports wildcards (+*+). (*Required*)

--- a/lib/elasticsearch-serverless/api/exists_source.rb
+++ b/lib/elasticsearch-serverless/api/exists_source.rb
@@ -21,7 +21,7 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Checks if a document's `_source` is stored.
+      # Checks if a document's +_source+ is stored.
       #
       # @option arguments [String] :id Identifier of the document. (*Required*)
       # @option arguments [String] :index Comma-separated list of data streams, indices, and aliases. Supports wildcards (+*+). (*Required*)

--- a/lib/elasticsearch-serverless/api/exists_source.rb
+++ b/lib/elasticsearch-serverless/api/exists_source.rb
@@ -21,7 +21,7 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Returns information about whether a document source exists in an index.
+      # Checks if a document's `_source` is stored.
       #
       # @option arguments [String] :id Identifier of the document. (*Required*)
       # @option arguments [String] :index Comma-separated list of data streams, indices, and aliases. Supports wildcards (+*+). (*Required*)

--- a/lib/elasticsearch-serverless/api/explain.rb
+++ b/lib/elasticsearch-serverless/api/explain.rb
@@ -21,7 +21,7 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Returns information about why a specific matches (or doesn't match) a query.
+      # Returns information about why a specific document matches (or doesn’t match) a query.
       #
       # @option arguments [String] :id Defines the document ID. (*Required*)
       # @option arguments [String] :index Index names used to limit the request. Only a single index name can be provided to this parameter. (*Required*)

--- a/lib/elasticsearch-serverless/api/field_caps.rb
+++ b/lib/elasticsearch-serverless/api/field_caps.rb
@@ -21,7 +21,9 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Returns the information about the capabilities of fields among multiple indices.
+      # The field capabilities API returns the information about the capabilities of fields among multiple indices.
+      # The field capabilities API returns runtime fields like any other field. For example, a runtime field with a type
+      # of keyword is returned as any other field that belongs to the `keyword` family.
       #
       # @option arguments [String, Array] :index Comma-separated list of data streams, indices, and aliases used to limit the request. Supports wildcards (*). To target all data streams and indices, omit this parameter or use * or _all.
       # @option arguments [Boolean] :allow_no_indices If false, the request returns an error if any wildcard expression, index alias, or +_all+ value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request targeting +foo*,bar*+ returns an error if an index starts with foo but no index starts with bar. Server default: true.
@@ -31,6 +33,7 @@ module ElasticsearchServerless
       # @option arguments [Boolean] :include_unmapped If true, unmapped fields are included in the response.
       # @option arguments [String] :filters An optional set of filters: can include +metadata,-metadata,-nested,-multifield,-parent
       # @option arguments [Array<String>] :types Only return results for fields that have one of the types in the list
+      # @option arguments [Boolean] :include_empty_fields If false, empty fields are not included in the response. Server default: true.
       # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body request body
       #

--- a/lib/elasticsearch-serverless/api/field_caps.rb
+++ b/lib/elasticsearch-serverless/api/field_caps.rb
@@ -23,7 +23,7 @@ module ElasticsearchServerless
     module Actions
       # The field capabilities API returns the information about the capabilities of fields among multiple indices.
       # The field capabilities API returns runtime fields like any other field. For example, a runtime field with a type
-      # of keyword is returned as any other field that belongs to the `keyword` family.
+      # of keyword is returned as any other field that belongs to the +keyword+ family.
       #
       # @option arguments [String, Array] :index Comma-separated list of data streams, indices, and aliases used to limit the request. Supports wildcards (*). To target all data streams and indices, omit this parameter or use * or _all.
       # @option arguments [Boolean] :allow_no_indices If false, the request returns an error if any wildcard expression, index alias, or +_all+ value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request targeting +foo*,bar*+ returns an error if an index starts with foo but no index starts with bar. Server default: true.

--- a/lib/elasticsearch-serverless/api/get.rb
+++ b/lib/elasticsearch-serverless/api/get.rb
@@ -25,6 +25,7 @@ module ElasticsearchServerless
       #
       # @option arguments [String] :id Unique identifier of the document. (*Required*)
       # @option arguments [String] :index Name of the index that contains the document. (*Required*)
+      # @option arguments [Boolean] :force_synthetic_source Should this request force synthetic _source? Use this to test if the mapping supports synthetic _source and to get a sense of the worst case performance. Fetches with this enabled will be slower the enabling synthetic source natively in the index.
       # @option arguments [String] :preference Specifies the node or shard the operation should be performed on. Random by default.
       # @option arguments [Boolean] :realtime If +true+, the request is real-time as opposed to near-real-time. Server default: true.
       # @option arguments [Boolean] :refresh If true, Elasticsearch refreshes the affected shards to make this operation visible to search. If false, do nothing with refreshes.

--- a/lib/elasticsearch-serverless/api/get_script.rb
+++ b/lib/elasticsearch-serverless/api/get_script.rb
@@ -21,7 +21,7 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Returns a script.
+      # Retrieves a stored script or search template.
       #
       # @option arguments [String] :id Identifier for the stored script or search template. (*Required*)
       # @option arguments [Time] :master_timeout Specify timeout for connection to master

--- a/lib/elasticsearch-serverless/api/graph/explore.rb
+++ b/lib/elasticsearch-serverless/api/graph/explore.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Graph
       module Actions
-        # Explore extracted and summarized information about the documents and terms in an index.
+        # Extracts and summarizes information about the documents and terms in an Elasticsearch data stream or index.
         #
         # @option arguments [String, Array] :index Name of the index. (*Required*)
         # @option arguments [String] :routing Custom value used to route operations to a specific shard.

--- a/lib/elasticsearch-serverless/api/index.rb
+++ b/lib/elasticsearch-serverless/api/index.rb
@@ -21,7 +21,8 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Creates or updates a document in an index.
+      # Adds a JSON document to the specified data stream or index and makes it searchable.
+      # If the target is an index and the document already exists, the request updates the document and increments its version.
       #
       # @option arguments [String] :id Unique identifier for the document.
       # @option arguments [String] :index Name of the data stream or index to target. (*Required*)

--- a/lib/elasticsearch-serverless/api/indices/analyze.rb
+++ b/lib/elasticsearch-serverless/api/indices/analyze.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Performs the analysis process on a text and return the tokens breakdown of the text.
+        # Performs analysis on a text string and returns the resulting tokens.
         #
         # @option arguments [String] :index Index used to derive the analyzer. If specified, the +analyzer+ or field parameter overrides this value. If no index is specified or the index does not have a default analyzer, the analyze API uses the standard analyzer.
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/indices/create.rb
+++ b/lib/elasticsearch-serverless/api/indices/create.rb
@@ -22,12 +22,12 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Creates an index with optional settings and mappings.
+        # Creates a new index.
         #
         # @option arguments [String] :index Name of the index you wish to create. (*Required*)
         # @option arguments [Time] :master_timeout Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error. Server default: 30s.
         # @option arguments [Time] :timeout Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error. Server default: 30s.
-        # @option arguments [Integer, String] :wait_for_active_shards The number of shard copies that must be active before proceeding with the operation.  Set to +all+ or any positive integer up to the total number of shards in the index (+number_of_replicas+1+). Server default: 1.
+        # @option arguments [Integer, String] :wait_for_active_shards The number of shard copies that must be active before proceeding with the operation. Set to +all+ or any positive integer up to the total number of shards in the index (+number_of_replicas+1+). Server default: 1.
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body request body
         #

--- a/lib/elasticsearch-serverless/api/indices/create_data_stream.rb
+++ b/lib/elasticsearch-serverless/api/indices/create_data_stream.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Creates a data stream
+        # Creates a data stream.
+        # You must have a matching index template with data stream enabled.
         #
         # @option arguments [String] :name Name of the data stream, which must meet the following criteria: Lowercase only; Cannot include +\+, +/+, +*+, +?+, +"+, +<+, +>+, +|+, +,+, +#+, +:+, or a space character; Cannot start with +-+, +_+, +++, or +.ds-+; Cannot be +.+ or +..+; Cannot be longer than 255 bytes. Multi-byte characters count towards this limit faster. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/indices/data_streams_stats.rb
+++ b/lib/elasticsearch-serverless/api/indices/data_streams_stats.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Provides statistics on operations happening in a data stream.
+        # Retrieves statistics for one or more data streams.
         #
         # @option arguments [String] :name Comma-separated list of data streams used to limit the request. Wildcard expressions (+*+) are supported. To target all data streams in a cluster, omit this parameter or use +*+.
         # @option arguments [String, Array<String>] :expand_wildcards Type of data stream that wildcard patterns can match. Supports comma-separated values, such as +open,hidden+. Server default: open.

--- a/lib/elasticsearch-serverless/api/indices/delete.rb
+++ b/lib/elasticsearch-serverless/api/indices/delete.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Deletes an index.
+        # Deletes one or more indices.
         #
         # @option arguments [String, Array] :index Comma-separated list of indices to delete. You cannot specify index aliases. By default, this parameter does not support wildcards (+*+) or +_all+. To use wildcards or +_all+, set the +action.destructive_requires_name+ cluster setting to +false+. (*Required*)
         # @option arguments [Boolean] :allow_no_indices If +false+, the request returns an error if any wildcard expression, index alias, or +_all+ value targets only missing or closed indices. This behavior applies even if the request targets other open indices. Server default: true.

--- a/lib/elasticsearch-serverless/api/indices/delete_alias.rb
+++ b/lib/elasticsearch-serverless/api/indices/delete_alias.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Deletes an alias.
+        # Removes a data stream or index from an alias.
         #
         # @option arguments [String, Array] :index Comma-separated list of data streams or indices used to limit the request. Supports wildcards (+*+). (*Required*)
         # @option arguments [String, Array<String>] :name Comma-separated list of aliases to remove. Supports wildcards (+*+). To remove all aliases, use +*+ or +_all+. (*Required*)

--- a/lib/elasticsearch-serverless/api/indices/delete_data_lifecycle.rb
+++ b/lib/elasticsearch-serverless/api/indices/delete_data_lifecycle.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Deletes the data stream lifecycle of the selected data streams.
+        # Removes the data lifecycle from a data stream rendering it not managed by the data stream lifecycle
         #
         # @option arguments [String, Array<String>] :name A comma-separated list of data streams of which the data stream lifecycle will be deleted; use +*+ to get all data streams (*Required*)
         # @option arguments [String, Array<String>] :expand_wildcards Whether wildcard expressions should get expanded to open or closed indices (default: open)

--- a/lib/elasticsearch-serverless/api/indices/delete_data_stream.rb
+++ b/lib/elasticsearch-serverless/api/indices/delete_data_stream.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Deletes a data stream.
+        # Deletes one or more data streams and their backing indices.
         #
         # @option arguments [String, Array<String>] :name Comma-separated list of data streams to delete. Wildcard (+*+) expressions are supported. (*Required*)
         # @option arguments [String, Array<String>] :expand_wildcards Type of data stream that wildcard patterns can match. Supports comma-separated values,such as +open,hidden+. Server default: open.

--- a/lib/elasticsearch-serverless/api/indices/delete_index_template.rb
+++ b/lib/elasticsearch-serverless/api/indices/delete_index_template.rb
@@ -22,7 +22,9 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Deletes an index template.
+        # The provided <index-template> may contain multiple template names separated by a comma. If multiple template
+        # names are specified then there is no wildcard support and the provided names should match completely with
+        # existing templates.
         #
         # @option arguments [String, Array<String>] :name Comma-separated list of index template names used to limit the request. Wildcard (*) expressions are supported. (*Required*)
         # @option arguments [Time] :master_timeout Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error. Server default: 30s.

--- a/lib/elasticsearch-serverless/api/indices/exists.rb
+++ b/lib/elasticsearch-serverless/api/indices/exists.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Returns information about whether a particular index exists.
+        # Checks if a data stream, index, or alias exists.
         #
         # @option arguments [String, Array] :index Comma-separated list of data streams, indices, and aliases. Supports wildcards (+*+). (*Required*)
         # @option arguments [Boolean] :allow_no_indices If +false+, the request returns an error if any wildcard expression, index alias, or +_all+ value targets only missing or closed indices. This behavior applies even if the request targets other open indices. Server default: true.

--- a/lib/elasticsearch-serverless/api/indices/exists_alias.rb
+++ b/lib/elasticsearch-serverless/api/indices/exists_alias.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Returns information about whether a particular alias exists.
+        # Checks if an alias exists.
         #
         # @option arguments [String, Array<String>] :name Comma-separated list of aliases to check. Supports wildcards (+*+). (*Required*)
         # @option arguments [String, Array] :index Comma-separated list of data streams or indices used to limit the request. Supports wildcards (+*+). To target all data streams and indices, omit this parameter or use +*+ or +_all+.

--- a/lib/elasticsearch-serverless/api/indices/get.rb
+++ b/lib/elasticsearch-serverless/api/indices/get.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Returns information about one or more indices.
+        # Returns information about one or more indices. For data streams, the API returns information about the
+        # stream’s backing indices.
         #
         # @option arguments [String, Array] :index Comma-separated list of data streams, indices, and index aliases used to limit the request. Wildcard expressions (*) are supported. (*Required*)
         # @option arguments [Boolean] :allow_no_indices If false, the request returns an error if any wildcard expression, index alias, or _all value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request targeting foo*,bar* returns an error if an index starts with foo but no index starts with bar. Server default: true.

--- a/lib/elasticsearch-serverless/api/indices/get_alias.rb
+++ b/lib/elasticsearch-serverless/api/indices/get_alias.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Returns an alias.
+        # Retrieves information for one or more aliases.
         #
         # @option arguments [String, Array<String>] :name Comma-separated list of aliases to retrieve. Supports wildcards (+*+). To retrieve all aliases, omit this parameter or use +*+ or +_all+.
         # @option arguments [String, Array] :index Comma-separated list of data streams or indices used to limit the request. Supports wildcards (+*+). To target all data streams and indices, omit this parameter or use +*+ or +_all+.

--- a/lib/elasticsearch-serverless/api/indices/get_data_lifecycle.rb
+++ b/lib/elasticsearch-serverless/api/indices/get_data_lifecycle.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Returns the data stream lifecycle of the selected data streams.
+        # Retrieves the data stream lifecycle configuration of one or more data streams.
         #
         # @option arguments [String, Array<String>] :name Comma-separated list of data streams to limit the request. Supports wildcards (+*+). To target all data streams, omit this parameter or use +*+ or +_all+. (*Required*)
         # @option arguments [String, Array<String>] :expand_wildcards Type of data stream that wildcard patterns can match. Supports comma-separated values, such as +open,hidden+. Valid values are: +all+, +open+, +closed+, +hidden+, +none+. Server default: open.

--- a/lib/elasticsearch-serverless/api/indices/get_data_stream.rb
+++ b/lib/elasticsearch-serverless/api/indices/get_data_stream.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Returns data streams.
+        # Retrieves information about one or more data streams.
         #
         # @option arguments [String, Array<String>] :name Comma-separated list of data stream names used to limit the request. Wildcard (+*+) expressions are supported. If omitted, all data streams are returned.
         # @option arguments [String, Array<String>] :expand_wildcards Type of data stream that wildcard patterns can match. Supports comma-separated values, such as +open,hidden+. Server default: open.

--- a/lib/elasticsearch-serverless/api/indices/get_index_template.rb
+++ b/lib/elasticsearch-serverless/api/indices/get_index_template.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Returns an index template.
+        # Returns information about one or more index templates.
         #
         # @option arguments [String] :name Comma-separated list of index template names used to limit the request. Wildcard (*) expressions are supported.
         # @option arguments [Boolean] :local If true, the request retrieves information from the local node only. Defaults to false, which means information is retrieved from the master node.

--- a/lib/elasticsearch-serverless/api/indices/get_mapping.rb
+++ b/lib/elasticsearch-serverless/api/indices/get_mapping.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Returns mappings for one or more indices.
+        # Retrieves mapping definitions for one or more indices.
+        # For data streams, the API retrieves mappings for the stream’s backing indices.
         #
         # @option arguments [String, Array] :index Comma-separated list of data streams, indices, and aliases used to limit the request. Supports wildcards (+*+). To target all data streams and indices, omit this parameter or use +*+ or +_all+.
         # @option arguments [Boolean] :allow_no_indices If +false+, the request returns an error if any wildcard expression, index alias, or +_all+ value targets only missing or closed indices. This behavior applies even if the request targets other open indices. Server default: true.

--- a/lib/elasticsearch-serverless/api/indices/get_settings.rb
+++ b/lib/elasticsearch-serverless/api/indices/get_settings.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Returns settings for one or more indices.
+        # Returns setting information for one or more indices. For data streams,
+        # returns setting information for the stream’s backing indices.
         #
         # @option arguments [String, Array] :index Comma-separated list of data streams, indices, and aliases used to limit the request. Supports wildcards (+*+). To target all data streams and indices, omit this parameter or use +*+ or +_all+.
         # @option arguments [String, Array<String>] :name Comma-separated list or wildcard expression of settings to retrieve.

--- a/lib/elasticsearch-serverless/api/indices/migrate_to_data_stream.rb
+++ b/lib/elasticsearch-serverless/api/indices/migrate_to_data_stream.rb
@@ -22,7 +22,16 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Migrates an alias to a data stream
+        # Converts an index alias to a data stream.
+        # You must have a matching index template that is data stream enabled.
+        # The alias must meet the following criteria:
+        # The alias must have a write index;
+        # All indices for the alias must have a `@timestamp` field mapping of a `date` or `date_nanos` field type;
+        # The alias must not have any filters;
+        # The alias must not use custom routing.
+        # If successful, the request removes the alias and creates a data stream with the same name.
+        # The indices for the alias become hidden backing indices for the stream.
+        # The write index for the alias becomes the write index for the stream.
         #
         # @option arguments [String] :name Name of the index alias to convert to a data stream. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/indices/migrate_to_data_stream.rb
+++ b/lib/elasticsearch-serverless/api/indices/migrate_to_data_stream.rb
@@ -26,7 +26,7 @@ module ElasticsearchServerless
         # You must have a matching index template that is data stream enabled.
         # The alias must meet the following criteria:
         # The alias must have a write index;
-        # All indices for the alias must have a `@timestamp` field mapping of a `date` or `date_nanos` field type;
+        # All indices for the alias must have a +@timestamp+ field mapping of a +date+ or +date_nanos+ field type;
         # The alias must not have any filters;
         # The alias must not use custom routing.
         # If successful, the request removes the alias and creates a data stream with the same name.

--- a/lib/elasticsearch-serverless/api/indices/modify_data_stream.rb
+++ b/lib/elasticsearch-serverless/api/indices/modify_data_stream.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Modifies a data stream
+        # Performs one or more data stream modification actions in a single atomic operation.
         #
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body request body

--- a/lib/elasticsearch-serverless/api/indices/put_alias.rb
+++ b/lib/elasticsearch-serverless/api/indices/put_alias.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Creates or updates an alias.
+        # Adds a data stream or index to an alias.
         #
         # @option arguments [String, Array] :index Comma-separated list of data streams or indices to add. Supports wildcards (+*+). Wildcard patterns that match both data streams and indices return an error. (*Required*)
         # @option arguments [String] :name Alias to update. If the alias doesn’t exist, the request creates it. Index alias names support date math. (*Required*)

--- a/lib/elasticsearch-serverless/api/indices/put_data_lifecycle.rb
+++ b/lib/elasticsearch-serverless/api/indices/put_data_lifecycle.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Updates the data stream lifecycle of the selected data streams.
+        # Update the data lifecycle of the specified data streams.
         #
         # @option arguments [String, Array<String>] :name Comma-separated list of data streams used to limit the request. Supports wildcards (+*+). To target all data streams use +*+ or +_all+. (*Required*)
         # @option arguments [String, Array<String>] :expand_wildcards Type of data stream that wildcard patterns can match. Supports comma-separated values, such as +open,hidden+. Valid values are: +all+, +hidden+, +open+, +closed+, +none+. Server default: open.

--- a/lib/elasticsearch-serverless/api/indices/put_index_template.rb
+++ b/lib/elasticsearch-serverless/api/indices/put_index_template.rb
@@ -23,6 +23,7 @@ module ElasticsearchServerless
     module Indices
       module Actions
         # Creates or updates an index template.
+        # Index templates define settings, mappings, and aliases that can be applied automatically to new indices.
         #
         # @option arguments [String] :name Index or template name (*Required*)
         # @option arguments [Boolean] :create If +true+, this request cannot replace or update existing index templates.

--- a/lib/elasticsearch-serverless/api/indices/put_mapping.rb
+++ b/lib/elasticsearch-serverless/api/indices/put_mapping.rb
@@ -22,7 +22,9 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Updates the index mappings.
+        # Adds new fields to an existing data stream or index.
+        # You can also use this API to change the search settings of existing fields.
+        # For data streams, these changes are applied to all backing indices by default.
         #
         # @option arguments [String, Array] :index A comma-separated list of index names the mapping should be added to (supports wildcards); use +_all+ or omit to add the mapping on all indices. (*Required*)
         # @option arguments [Boolean] :allow_no_indices If +false+, the request returns an error if any wildcard expression, index alias, or +_all+ value targets only missing or closed indices. This behavior applies even if the request targets other open indices. Server default: true.

--- a/lib/elasticsearch-serverless/api/indices/put_settings.rb
+++ b/lib/elasticsearch-serverless/api/indices/put_settings.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Updates the index settings.
+        # Changes a dynamic index setting in real time. For data streams, index setting
+        # changes are applied to all backing indices by default.
         #
         # @option arguments [String, Array] :index Comma-separated list of data streams, indices, and aliases used to limit the request. Supports wildcards (+*+). To target all data streams and indices, omit this parameter or use +*+ or +_all+.
         # @option arguments [Boolean] :allow_no_indices If +false+, the request returns an error if any wildcard expression, index alias, or +_all+ value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request targeting +foo*,bar*+ returns an error if an index starts with +foo+ but no index starts with +bar+.

--- a/lib/elasticsearch-serverless/api/indices/refresh.rb
+++ b/lib/elasticsearch-serverless/api/indices/refresh.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Performs the refresh operation in one or more indices.
+        # A refresh makes recent operations performed on one or more indices available for search.
+        # For data streams, the API runs the refresh operation on the stream’s backing indices.
         #
         # @option arguments [String, Array] :index Comma-separated list of data streams, indices, and aliases used to limit the request. Supports wildcards (+*+). To target all data streams and indices, omit this parameter or use +*+ or +_all+.
         # @option arguments [Boolean] :allow_no_indices If +false+, the request returns an error if any wildcard expression, index alias, or +_all+ value targets only missing or closed indices. This behavior applies even if the request targets other open indices. Server default: true.

--- a/lib/elasticsearch-serverless/api/indices/resolve_index.rb
+++ b/lib/elasticsearch-serverless/api/indices/resolve_index.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Returns information about any matching indices, aliases, and data streams
+        # Resolves the specified name(s) and/or index patterns for indices, aliases, and data streams.
+        # Multiple patterns and remote clusters are supported.
         #
         # @option arguments [String, Array<String>] :name Comma-separated name(s) or index pattern(s) of the indices, aliases, and data streams to resolve. Resources on remote clusters can be specified using the +<cluster>+:+<name>+ syntax. (*Required*)
         # @option arguments [String, Array<String>] :expand_wildcards Type of index that wildcard patterns can match. If the request can target data streams, this argument determines whether wildcard expressions match hidden data streams. Supports comma-separated values, such as +open,hidden+. Valid values are: +all+, +open+, +closed+, +hidden+, +none+. Server default: open.

--- a/lib/elasticsearch-serverless/api/indices/rollover.rb
+++ b/lib/elasticsearch-serverless/api/indices/rollover.rb
@@ -22,8 +22,7 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Updates an alias to point to a new index when the existing index
-        # is considered to be too large or too old.
+        # Creates a new index for a data stream or index alias.
         #
         # @option arguments [String] :alias Name of the data stream or index alias to roll over. (*Required*)
         # @option arguments [String] :new_index Name of the index to create. Supports date math. Data streams do not support this parameter.

--- a/lib/elasticsearch-serverless/api/indices/simulate_template.rb
+++ b/lib/elasticsearch-serverless/api/indices/simulate_template.rb
@@ -22,14 +22,14 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Simulate resolving the given template name or body
+        # Returns the index configuration that would be applied by a particular index template.
         #
         # @option arguments [String] :name Name of the index template to simulate. To test a template configuration before you add it to the cluster, omit this parameter and specify the template configuration in the request body.
         # @option arguments [Boolean] :create If true, the template passed in the body is only used if no existing templates match the same index patterns. If false, the simulation uses the template with the highest priority. Note that the template is not permanently added or updated in either case; it is only used for the simulation.
         # @option arguments [Time] :master_timeout Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error. Server default: 30s.
         # @option arguments [Boolean] :include_defaults If true, returns all relevant default configurations for the index template.
         # @option arguments [Hash] :headers Custom HTTP headers
-        # @option arguments [Hash] :body template
+        # @option arguments [Hash] :body request body
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-simulate-template.html
         #

--- a/lib/elasticsearch-serverless/api/indices/update_aliases.rb
+++ b/lib/elasticsearch-serverless/api/indices/update_aliases.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Updates index aliases.
+        # Adds a data stream or index to an alias.
         #
         # @option arguments [Time] :master_timeout Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error. Server default: 30s.
         # @option arguments [Time] :timeout Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error. Server default: 30s.

--- a/lib/elasticsearch-serverless/api/indices/validate_query.rb
+++ b/lib/elasticsearch-serverless/api/indices/validate_query.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Allows a user to validate a potentially expensive query without executing it.
+        # Validates a potentially expensive query without executing it.
         #
         # @option arguments [String, Array] :index Comma-separated list of data streams, indices, and aliases to search. Supports wildcards (+*+). To search all data streams or indices, omit this parameter or use +*+ or +_all+.
         # @option arguments [Boolean] :allow_no_indices If +false+, the request returns an error if any wildcard expression, index alias, or +_all+ value targets only missing or closed indices. This behavior applies even if the request targets other open indices. Server default: true.

--- a/lib/elasticsearch-serverless/api/ingest/delete_pipeline.rb
+++ b/lib/elasticsearch-serverless/api/ingest/delete_pipeline.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Ingest
       module Actions
-        # Deletes a pipeline.
+        # Deletes one or more existing ingest pipeline.
         #
         # @option arguments [String] :id Pipeline ID or wildcard expression of pipeline IDs used to limit the request. To delete all ingest pipelines in a cluster, use a value of +*+. (*Required*)
         # @option arguments [Time] :master_timeout Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error. Server default: 30s.

--- a/lib/elasticsearch-serverless/api/ingest/get_pipeline.rb
+++ b/lib/elasticsearch-serverless/api/ingest/get_pipeline.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module Ingest
       module Actions
-        # Returns a pipeline.
+        # Returns information about one or more ingest pipelines.
+        # This API returns a local reference of the pipeline.
         #
         # @option arguments [String] :id Comma-separated list of pipeline IDs to retrieve. Wildcard (+*+) expressions are supported. To get all ingest pipelines, omit this parameter or use +*+.
         # @option arguments [Time] :master_timeout Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error. Server default: 30s.

--- a/lib/elasticsearch-serverless/api/ingest/processor_grok.rb
+++ b/lib/elasticsearch-serverless/api/ingest/processor_grok.rb
@@ -22,7 +22,9 @@ module ElasticsearchServerless
   module API
     module Ingest
       module Actions
-        # Returns a list of the built-in patterns.
+        # Extracts structured fields out of a single text field within a document.
+        # You choose which field to extract matched fields from, as well as the grok pattern you expect will match.
+        # A grok pattern is like a regular expression that supports aliased expressions that can be reused.
         #
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/lib/elasticsearch-serverless/api/ingest/put_pipeline.rb
+++ b/lib/elasticsearch-serverless/api/ingest/put_pipeline.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module Ingest
       module Actions
-        # Creates or updates a pipeline.
+        # Creates or updates an ingest pipeline.
+        # Changes made using this API take effect immediately.
         #
         # @option arguments [String] :id ID of the ingest pipeline to create or update. (*Required*)
         # @option arguments [Time] :master_timeout Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error. Server default: 30s.

--- a/lib/elasticsearch-serverless/api/ingest/simulate.rb
+++ b/lib/elasticsearch-serverless/api/ingest/simulate.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Ingest
       module Actions
-        # Allows to simulate a pipeline with example documents.
+        # Executes an ingest pipeline against a set of provided documents.
         #
         # @option arguments [String] :id Pipeline to test. If you don’t specify a +pipeline+ in the request body, this parameter is required.
         # @option arguments [Boolean] :verbose If +true+, the response includes output data for each processor in the executed pipeline.

--- a/lib/elasticsearch-serverless/api/license/get.rb
+++ b/lib/elasticsearch-serverless/api/license/get.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module License
       module Actions
-        # Retrieves licensing information for the cluster
+        # This API returns information about the type of license, when it was issued, and when it expires, for example.
+        # For more information about the different types of licenses, see https://www.elastic.co/subscriptions.
         #
         # @option arguments [Boolean] :accept_enterprise If +true+, this parameter returns enterprise for Enterprise license types. If +false+, this parameter returns platinum for both platinum and enterprise license types. This behavior is maintained for backwards compatibility. This parameter is deprecated and will always be set to true in 8.x. Server default: true.
         # @option arguments [Boolean] :local Specifies whether to retrieve local information. The default value is +false+, which means the information is retrieved from the master node.

--- a/lib/elasticsearch-serverless/api/logstash/delete_pipeline.rb
+++ b/lib/elasticsearch-serverless/api/logstash/delete_pipeline.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Logstash
       module Actions
-        # Deletes Logstash Pipelines used by Central Management
+        # Deletes a pipeline used for Logstash Central Management.
         #
         # @option arguments [String] :id Identifier for the pipeline. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/logstash/get_pipeline.rb
+++ b/lib/elasticsearch-serverless/api/logstash/get_pipeline.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Logstash
       module Actions
-        # Retrieves Logstash Pipelines used by Central Management
+        # Retrieves pipelines used for Logstash Central Management.
         #
         # @option arguments [String, Array] :id Comma-separated list of pipeline identifiers.
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/logstash/put_pipeline.rb
+++ b/lib/elasticsearch-serverless/api/logstash/put_pipeline.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Logstash
       module Actions
-        # Adds and updates Logstash Pipelines used for Central Management
+        # Creates or updates a pipeline used for Logstash Central Management.
         #
         # @option arguments [String] :id Identifier for the pipeline. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/machine_learning/close_job.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/close_job.rb
@@ -22,7 +22,11 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Closes one or more anomaly detection jobs. A job can be opened and closed multiple times throughout its lifecycle.
+        # Close anomaly detection jobs
+        # A job can be opened and closed multiple times throughout its lifecycle. A closed job cannot receive data or perform analysis operations, but you can still explore and navigate results.
+        # When you close a job, it runs housekeeping tasks such as pruning the model history, flushing buffers, calculating final results and persisting the model snapshots. Depending upon the size of the job, it could take several minutes to close and the equivalent time to re-open. After it is closed, the job has a minimal overhead on the cluster except for maintaining its meta data. Therefore it is a best practice to close jobs that are no longer required to process data.
+        # If you close an anomaly detection job whose datafeed is running, the request first tries to stop the datafeed. This behavior is equivalent to calling stop datafeed API with the same timeout and force parameters as the close job request.
+        # When a datafeed that has a specified end date stops, it automatically closes its associated job.
         #
         # @option arguments [String] :job_id Identifier for the anomaly detection job. It can be a job identifier, a group name, or a wildcard expression. You can close multiple anomaly detection jobs in a single API request by using a group name, a comma-separated list of jobs, or a wildcard expression. You can close all jobs by using +_all+ or by specifying +*+ as the job identifier. (*Required*)
         # @option arguments [Boolean] :allow_no_match Specifies what to do when the request: contains wildcard expressions and there are no jobs that match; contains the  +_all+ string or no identifiers and there are no matches; or contains wildcard expressions and there are only partial matches. By default, it returns an empty jobs array when there are no matches and the subset of results when there are partial matches. If +false+, the request returns a 404 status code when there are no matches or only partial matches. Server default: true.

--- a/lib/elasticsearch-serverless/api/machine_learning/delete_calendar.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/delete_calendar.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Deletes a calendar.
+        # Removes all scheduled events from a calendar, then deletes it.
         #
         # @option arguments [String] :calendar_id A string that uniquely identifies a calendar. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/machine_learning/delete_data_frame_analytics.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/delete_data_frame_analytics.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Deletes an existing data frame analytics job.
+        # Deletes a data frame analytics job.
         #
         # @option arguments [String] :id Identifier for the data frame analytics job. (*Required*)
         # @option arguments [Boolean] :force If +true+, it deletes a job that is not stopped; this method is quicker than stopping and deleting the job.

--- a/lib/elasticsearch-serverless/api/machine_learning/delete_filter.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/delete_filter.rb
@@ -23,6 +23,8 @@ module ElasticsearchServerless
     module MachineLearning
       module Actions
         # Deletes a filter.
+        # If an anomaly detection job references the filter, you cannot delete the
+        # filter. You must update or delete the job before you can delete the filter.
         #
         # @option arguments [String] :filter_id A string that uniquely identifies a filter. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/machine_learning/delete_job.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/delete_job.rb
@@ -22,7 +22,14 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Deletes an existing anomaly detection job.
+        # Deletes an anomaly detection job.
+        #
+        # All job configuration, model state and results are deleted.
+        # It is not currently possible to delete multiple jobs using wildcards or a
+        # comma separated list. If you delete a job that has a datafeed, the request
+        # first tries to delete the datafeed. This behavior is equivalent to calling
+        # the delete datafeed API with the same timeout and force parameters as the
+        # delete job request.
         #
         # @option arguments [String] :job_id Identifier for the anomaly detection job. (*Required*)
         # @option arguments [Boolean] :force Use to forcefully delete an opened job; this method is quicker than closing and deleting the job.

--- a/lib/elasticsearch-serverless/api/machine_learning/delete_trained_model.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/delete_trained_model.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Deletes an existing trained inference model that is currently not referenced by an ingest pipeline.
+        # Deletes an existing trained inference model that is currently not referenced
+        # by an ingest pipeline.
         #
         # @option arguments [String] :model_id The unique identifier of the trained model. (*Required*)
         # @option arguments [Boolean] :force Forcefully deletes a trained model that is referenced by ingest pipelines or has a started deployment.

--- a/lib/elasticsearch-serverless/api/machine_learning/delete_trained_model_alias.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/delete_trained_model_alias.rb
@@ -25,7 +25,7 @@ module ElasticsearchServerless
         # Deletes a trained model alias.
         # This API deletes an existing model alias that refers to a trained model. If
         # the model alias is missing or refers to a model other than the one identified
-        # by the `model_id`, this API returns an error.
+        # by the +model_id+, this API returns an error.
         #
         # @option arguments [String] :model_alias The model alias to delete. (*Required*)
         # @option arguments [String] :model_id The trained model ID to which the model alias refers. (*Required*)

--- a/lib/elasticsearch-serverless/api/machine_learning/delete_trained_model_alias.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/delete_trained_model_alias.rb
@@ -22,7 +22,10 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Deletes a model alias that refers to the trained model
+        # Deletes a trained model alias.
+        # This API deletes an existing model alias that refers to a trained model. If
+        # the model alias is missing or refers to a model other than the one identified
+        # by the `model_id`, this API returns an error.
         #
         # @option arguments [String] :model_alias The model alias to delete. (*Required*)
         # @option arguments [String] :model_id The trained model ID to which the model alias refers. (*Required*)

--- a/lib/elasticsearch-serverless/api/machine_learning/estimate_model_memory.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/estimate_model_memory.rb
@@ -22,7 +22,9 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Estimates the model memory
+        # Makes an estimation of the memory usage for an anomaly detection job model.
+        # It is based on analysis configuration details for the job and cardinality
+        # estimates for the fields it references.
         #
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body request body

--- a/lib/elasticsearch-serverless/api/machine_learning/evaluate_data_frame.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/evaluate_data_frame.rb
@@ -23,6 +23,10 @@ module ElasticsearchServerless
     module MachineLearning
       module Actions
         # Evaluates the data frame analytics for an annotated index.
+        # The API packages together commonly used evaluation metrics for various types
+        # of machine learning features. This has been designed for use on indexes
+        # created by data frame analytics. Evaluation requires both a ground truth
+        # field and an analytics result field to be present.
         #
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body request body

--- a/lib/elasticsearch-serverless/api/machine_learning/flush_job.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/flush_job.rb
@@ -23,6 +23,14 @@ module ElasticsearchServerless
     module MachineLearning
       module Actions
         # Forces any buffered data to be processed by the job.
+        # The flush jobs API is only applicable when sending data for analysis using
+        # the post data API. Depending on the content of the buffer, then it might
+        # additionally calculate new results. Both flush and close operations are
+        # similar, however the flush is more efficient if you are expecting to send
+        # more data for analysis. When flushing, the job remains open and is available
+        # to continue analyzing data. A close operation additionally prunes and
+        # persists the model state to disk and the job must be opened again before
+        # analyzing further data.
         #
         # @option arguments [String] :job_id Identifier for the anomaly detection job. (*Required*)
         # @option arguments [String, Time] :advance_time Specifies to advance to a particular time value. Results are generated and the model is updated for data from the specified time interval.

--- a/lib/elasticsearch-serverless/api/machine_learning/get_data_frame_analytics.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/get_data_frame_analytics.rb
@@ -23,6 +23,9 @@ module ElasticsearchServerless
     module MachineLearning
       module Actions
         # Retrieves configuration information for data frame analytics jobs.
+        # You can get information for multiple data frame analytics jobs in a single
+        # API request by using a comma-separated list of data frame analytics jobs or a
+        # wildcard expression.
         #
         # @option arguments [String] :id Identifier for the data frame analytics job. If you do not specify this option, the API returns information for the first hundred data frame analytics jobs.
         # @option arguments [Boolean] :allow_no_match Specifies what to do when the request:  1. Contains wildcard expressions and there are no data frame analytics jobs that match. 2. Contains the +_all+ string or no identifiers and there are no matches. 3. Contains wildcard expressions and there are only partial matches.  The default value returns an empty data_frame_analytics array when there are no matches and the subset of results when there are partial matches. If this parameter is +false+, the request returns a 404 status code when there are no matches or only partial matches. Server default: true.

--- a/lib/elasticsearch-serverless/api/machine_learning/get_datafeed_stats.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/get_datafeed_stats.rb
@@ -23,6 +23,12 @@ module ElasticsearchServerless
     module MachineLearning
       module Actions
         # Retrieves usage information for datafeeds.
+        # You can get statistics for multiple datafeeds in a single API request by
+        # using a comma-separated list of datafeeds or a wildcard expression. You can
+        # get statistics for all datafeeds by using `_all`, by specifying `*` as the
+        # `<feed_id>`, or by omitting the `<feed_id>`. If the datafeed is stopped, the
+        # only information you receive is the `datafeed_id` and the `state`.
+        # This API returns a maximum of 10,000 datafeeds.
         #
         # @option arguments [String, Array] :datafeed_id Identifier for the datafeed. It can be a datafeed identifier or a wildcard expression. If you do not specify one of these options, the API returns information about all datafeeds.
         # @option arguments [Boolean] :allow_no_match Specifies what to do when the request:  1. Contains wildcard expressions and there are no datafeeds that match. 2. Contains the +_all+ string or no identifiers and there are no matches. 3. Contains wildcard expressions and there are only partial matches.  The default value is +true+, which returns an empty +datafeeds+ array when there are no matches and the subset of results when there are partial matches. If this parameter is +false+, the request returns a +404+ status code when there are no matches or only partial matches.

--- a/lib/elasticsearch-serverless/api/machine_learning/get_datafeed_stats.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/get_datafeed_stats.rb
@@ -25,9 +25,9 @@ module ElasticsearchServerless
         # Retrieves usage information for datafeeds.
         # You can get statistics for multiple datafeeds in a single API request by
         # using a comma-separated list of datafeeds or a wildcard expression. You can
-        # get statistics for all datafeeds by using `_all`, by specifying `*` as the
-        # `<feed_id>`, or by omitting the `<feed_id>`. If the datafeed is stopped, the
-        # only information you receive is the `datafeed_id` and the `state`.
+        # get statistics for all datafeeds by using +_all+, by specifying +*+ as the
+        # +<feed_id>+, or by omitting the +<feed_id>+. If the datafeed is stopped, the
+        # only information you receive is the +datafeed_id+ and the +state+.
         # This API returns a maximum of 10,000 datafeeds.
         #
         # @option arguments [String, Array] :datafeed_id Identifier for the datafeed. It can be a datafeed identifier or a wildcard expression. If you do not specify one of these options, the API returns information about all datafeeds.

--- a/lib/elasticsearch-serverless/api/machine_learning/get_datafeeds.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/get_datafeeds.rb
@@ -23,6 +23,11 @@ module ElasticsearchServerless
     module MachineLearning
       module Actions
         # Retrieves configuration information for datafeeds.
+        # You can get information for multiple datafeeds in a single API request by
+        # using a comma-separated list of datafeeds or a wildcard expression. You can
+        # get information for all datafeeds by using `_all`, by specifying `*` as the
+        # `<feed_id>`, or by omitting the `<feed_id>`.
+        # This API returns a maximum of 10,000 datafeeds.
         #
         # @option arguments [String, Array] :datafeed_id Identifier for the datafeed. It can be a datafeed identifier or a wildcard expression. If you do not specify one of these options, the API returns information about all datafeeds.
         # @option arguments [Boolean] :allow_no_match Specifies what to do when the request:  1. Contains wildcard expressions and there are no datafeeds that match. 2. Contains the +_all+ string or no identifiers and there are no matches. 3. Contains wildcard expressions and there are only partial matches.  The default value is +true+, which returns an empty +datafeeds+ array when there are no matches and the subset of results when there are partial matches. If this parameter is +false+, the request returns a +404+ status code when there are no matches or only partial matches.

--- a/lib/elasticsearch-serverless/api/machine_learning/get_datafeeds.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/get_datafeeds.rb
@@ -25,8 +25,8 @@ module ElasticsearchServerless
         # Retrieves configuration information for datafeeds.
         # You can get information for multiple datafeeds in a single API request by
         # using a comma-separated list of datafeeds or a wildcard expression. You can
-        # get information for all datafeeds by using `_all`, by specifying `*` as the
-        # `<feed_id>`, or by omitting the `<feed_id>`.
+        # get information for all datafeeds by using +_all+, by specifying +*+ as the
+        # +<feed_id>+, or by omitting the +<feed_id>+.
         # This API returns a maximum of 10,000 datafeeds.
         #
         # @option arguments [String, Array] :datafeed_id Identifier for the datafeed. It can be a datafeed identifier or a wildcard expression. If you do not specify one of these options, the API returns information about all datafeeds.

--- a/lib/elasticsearch-serverless/api/machine_learning/get_filters.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/get_filters.rb
@@ -23,6 +23,7 @@ module ElasticsearchServerless
     module MachineLearning
       module Actions
         # Retrieves filters.
+        # You can get a single filter or all filters.
         #
         # @option arguments [String, Array] :filter_id A string that uniquely identifies a filter.
         # @option arguments [Integer] :from Skips the specified number of filters. Server default: 0.

--- a/lib/elasticsearch-serverless/api/machine_learning/get_jobs.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/get_jobs.rb
@@ -26,7 +26,7 @@ module ElasticsearchServerless
         # You can get information for multiple anomaly detection jobs in a single API
         # request by using a group name, a comma-separated list of jobs, or a wildcard
         # expression. You can get information for all anomaly detection jobs by using
-        # `_all`, by specifying `*` as the `<job_id>`, or by omitting the `<job_id>`.
+        # +_all+, by specifying +*+ as the +<job_id>+, or by omitting the +<job_id>+.
         #
         # @option arguments [String, Array] :job_id Identifier for the anomaly detection job. It can be a job identifier, a group name, or a wildcard expression. If you do not specify one of these options, the API returns information for all anomaly detection jobs.
         # @option arguments [Boolean] :allow_no_match Specifies what to do when the request:  1. Contains wildcard expressions and there are no jobs that match. 2. Contains the _all string or no identifiers and there are no matches. 3. Contains wildcard expressions and there are only partial matches.  The default value is +true+, which returns an empty +jobs+ array when there are no matches and the subset of results when there are partial matches. If this parameter is +false+, the request returns a +404+ status code when there are no matches or only partial matches. Server default: true.

--- a/lib/elasticsearch-serverless/api/machine_learning/get_jobs.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/get_jobs.rb
@@ -23,6 +23,10 @@ module ElasticsearchServerless
     module MachineLearning
       module Actions
         # Retrieves configuration information for anomaly detection jobs.
+        # You can get information for multiple anomaly detection jobs in a single API
+        # request by using a group name, a comma-separated list of jobs, or a wildcard
+        # expression. You can get information for all anomaly detection jobs by using
+        # `_all`, by specifying `*` as the `<job_id>`, or by omitting the `<job_id>`.
         #
         # @option arguments [String, Array] :job_id Identifier for the anomaly detection job. It can be a job identifier, a group name, or a wildcard expression. If you do not specify one of these options, the API returns information for all anomaly detection jobs.
         # @option arguments [Boolean] :allow_no_match Specifies what to do when the request:  1. Contains wildcard expressions and there are no jobs that match. 2. Contains the _all string or no identifiers and there are no matches. 3. Contains wildcard expressions and there are only partial matches.  The default value is +true+, which returns an empty +jobs+ array when there are no matches and the subset of results when there are partial matches. If this parameter is +false+, the request returns a +404+ status code when there are no matches or only partial matches. Server default: true.

--- a/lib/elasticsearch-serverless/api/machine_learning/get_overall_buckets.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/get_overall_buckets.rb
@@ -22,7 +22,23 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Retrieves overall bucket results that summarize the bucket results of multiple anomaly detection jobs.
+        # Retrieves overall bucket results that summarize the bucket results of
+        # multiple anomaly detection jobs.
+        #
+        # The `overall_score` is calculated by combining the scores of all the
+        # buckets within the overall bucket span. First, the maximum
+        # `anomaly_score` per anomaly detection job in the overall bucket is
+        # calculated. Then the `top_n` of those scores are averaged to result in
+        # the `overall_score`. This means that you can fine-tune the
+        # `overall_score` so that it is more or less sensitive to the number of
+        # jobs that detect an anomaly at the same time. For example, if you set
+        # `top_n` to `1`, the `overall_score` is the maximum bucket score in the
+        # overall bucket. Alternatively, if you set `top_n` to the number of jobs,
+        # the `overall_score` is high only when all jobs detect anomalies in that
+        # overall bucket. If you set the `bucket_span` parameter (to a value
+        # greater than its default), the `overall_score` is the maximum
+        # `overall_score` of the overall buckets that have a span equal to the
+        # jobs' largest bucket span.
         #
         # @option arguments [String] :job_id Identifier for the anomaly detection job. It can be a job identifier, a group name, a comma-separated list of jobs or groups, or a wildcard expression.  You can summarize the bucket results for all anomaly detection jobs by using +_all+ or by specifying +*+ as the +<job_id>+. (*Required*)
         # @option arguments [Boolean] :allow_no_match Specifies what to do when the request:  1. Contains wildcard expressions and there are no jobs that match. 2. Contains the +_all+ string or no identifiers and there are no matches. 3. Contains wildcard expressions and there are only partial matches.  If +true+, the request returns an empty +jobs+ array when there are no matches and the subset of results when there are partial matches. If this parameter is +false+, the request returns a +404+ status code when there are no matches or only partial matches. Server default: true.

--- a/lib/elasticsearch-serverless/api/machine_learning/get_overall_buckets.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/get_overall_buckets.rb
@@ -25,19 +25,19 @@ module ElasticsearchServerless
         # Retrieves overall bucket results that summarize the bucket results of
         # multiple anomaly detection jobs.
         #
-        # The `overall_score` is calculated by combining the scores of all the
+        # The +overall_score+ is calculated by combining the scores of all the
         # buckets within the overall bucket span. First, the maximum
-        # `anomaly_score` per anomaly detection job in the overall bucket is
-        # calculated. Then the `top_n` of those scores are averaged to result in
-        # the `overall_score`. This means that you can fine-tune the
-        # `overall_score` so that it is more or less sensitive to the number of
+        # +anomaly_score+ per anomaly detection job in the overall bucket is
+        # calculated. Then the +top_n+ of those scores are averaged to result in
+        # the +overall_score+. This means that you can fine-tune the
+        # +overall_score+ so that it is more or less sensitive to the number of
         # jobs that detect an anomaly at the same time. For example, if you set
-        # `top_n` to `1`, the `overall_score` is the maximum bucket score in the
-        # overall bucket. Alternatively, if you set `top_n` to the number of jobs,
-        # the `overall_score` is high only when all jobs detect anomalies in that
-        # overall bucket. If you set the `bucket_span` parameter (to a value
-        # greater than its default), the `overall_score` is the maximum
-        # `overall_score` of the overall buckets that have a span equal to the
+        # +top_n+ to +1+, the +overall_score+ is the maximum bucket score in the
+        # overall bucket. Alternatively, if you set +top_n+ to the number of jobs,
+        # the +overall_score+ is high only when all jobs detect anomalies in that
+        # overall bucket. If you set the +bucket_span+ parameter (to a value
+        # greater than its default), the +overall_score+ is the maximum
+        # +overall_score+ of the overall buckets that have a span equal to the
         # jobs' largest bucket span.
         #
         # @option arguments [String] :job_id Identifier for the anomaly detection job. It can be a job identifier, a group name, a comma-separated list of jobs or groups, or a wildcard expression.  You can summarize the bucket results for all anomaly detection jobs by using +_all+ or by specifying +*+ as the +<job_id>+. (*Required*)

--- a/lib/elasticsearch-serverless/api/machine_learning/get_trained_models.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/get_trained_models.rb
@@ -22,9 +22,9 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Retrieves configuration information for a trained inference model.
+        # Retrieves configuration information for a trained model.
         #
-        # @option arguments [String] :model_id The unique identifier of the trained model.
+        # @option arguments [String, Array] :model_id The unique identifier of the trained model or a model alias.  You can get information for multiple trained models in a single API request by using a comma-separated list of model IDs or a wildcard expression.
         # @option arguments [Boolean] :allow_no_match Specifies what to do when the request:  - Contains wildcard expressions and there are no models that match. - Contains the _all string or no identifiers and there are no matches. - Contains wildcard expressions and there are only partial matches.  If true, it returns an empty array when there are no matches and the subset of results when there are partial matches. Server default: true.
         # @option arguments [Boolean] :decompress_definition Specifies whether the included model definition should be returned as a JSON map (true) or in a custom compressed format (false). Server default: true.
         # @option arguments [Boolean] :exclude_generated Indicates if certain fields should be removed from the configuration on retrieval. This allows the configuration to be in an acceptable format to be retrieved and then added to another cluster.

--- a/lib/elasticsearch-serverless/api/machine_learning/get_trained_models_stats.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/get_trained_models_stats.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Retrieves usage information for trained inference models.
+        # Retrieves usage information for trained models. You can get usage information for multiple trained
+        # models in a single API request by using a comma-separated list of model IDs or a wildcard expression.
         #
         # @option arguments [String, Array] :model_id The unique identifier of the trained model or a model alias. It can be a comma-separated list or a wildcard expression.
         # @option arguments [Boolean] :allow_no_match Specifies what to do when the request:  - Contains wildcard expressions and there are no models that match. - Contains the _all string or no identifiers and there are no matches. - Contains wildcard expressions and there are only partial matches.  If true, it returns an empty array when there are no matches and the subset of results when there are partial matches. Server default: true.

--- a/lib/elasticsearch-serverless/api/machine_learning/open_job.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/open_job.rb
@@ -23,6 +23,13 @@ module ElasticsearchServerless
     module MachineLearning
       module Actions
         # Opens one or more anomaly detection jobs.
+        # An anomaly detection job must be opened in order for it to be ready to
+        # receive and analyze data. It can be opened and closed multiple times
+        # throughout its lifecycle.
+        # When you open a new job, it starts with an empty model.
+        # When you open an existing job, the most recent model state is automatically
+        # loaded. The job is ready to resume its analysis from where it left off, once
+        # new data is received.
         #
         # @option arguments [String] :job_id Identifier for the anomaly detection job. (*Required*)
         # @option arguments [Time] :timeout Controls the time to wait until a job has opened. Server default: 30m.

--- a/lib/elasticsearch-serverless/api/machine_learning/post_calendar_events.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/post_calendar_events.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Posts scheduled events in a calendar.
+        # Adds scheduled events to a calendar.
         #
         # @option arguments [String] :calendar_id A string that uniquely identifies a calendar. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/machine_learning/preview_data_frame_analytics.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/preview_data_frame_analytics.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Previews that will be analyzed given a data frame analytics config.
+        # Previews the extracted features used by a data frame analytics config.
         #
         # @option arguments [String] :id Identifier for the data frame analytics job.
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/machine_learning/preview_datafeed.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/preview_datafeed.rb
@@ -23,6 +23,14 @@ module ElasticsearchServerless
     module MachineLearning
       module Actions
         # Previews a datafeed.
+        # This API returns the first "page" of search results from a datafeed.
+        # You can preview an existing datafeed or provide configuration details for a datafeed
+        # and anomaly detection job in the API. The preview shows the structure of the data
+        # that will be passed to the anomaly detection engine.
+        # IMPORTANT: When Elasticsearch security features are enabled, the preview uses the credentials of the user that
+        # called the API. However, when the datafeed starts it uses the roles of the last user that created or updated the
+        # datafeed. To get a preview that accurately reflects the behavior of the datafeed, use the appropriate credentials.
+        # You can also use secondary authorization headers to supply the credentials.
         #
         # @option arguments [String] :datafeed_id A numerical character string that uniquely identifies the datafeed. This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric characters. NOTE: If you use this path parameter, you cannot provide datafeed or anomaly detection job configuration details in the request body.
         # @option arguments [String, Time] :start The start time from where the datafeed preview should begin

--- a/lib/elasticsearch-serverless/api/machine_learning/put_calendar.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/put_calendar.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Instantiates a calendar.
+        # Creates a calendar.
         #
         # @option arguments [String] :calendar_id A string that uniquely identifies a calendar. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/machine_learning/put_calendar_job.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/put_calendar_job.rb
@@ -25,7 +25,7 @@ module ElasticsearchServerless
         # Adds an anomaly detection job to a calendar.
         #
         # @option arguments [String] :calendar_id A string that uniquely identifies a calendar. (*Required*)
-        # @option arguments [String] :job_id An identifier for the anomaly detection jobs. It can be a job identifier, a group name, or a comma-separated list of jobs or groups. (*Required*)
+        # @option arguments [String, Array] :job_id An identifier for the anomaly detection jobs. It can be a job identifier, a group name, or a comma-separated list of jobs or groups. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-calendar-job.html

--- a/lib/elasticsearch-serverless/api/machine_learning/put_data_frame_analytics.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/put_data_frame_analytics.rb
@@ -23,6 +23,8 @@ module ElasticsearchServerless
     module MachineLearning
       module Actions
         # Instantiates a data frame analytics job.
+        # This API creates a data frame analytics job that performs an analysis on the
+        # source indices and stores the outcome in a destination index.
         #
         # @option arguments [String] :id Identifier for the data frame analytics job. This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric characters. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/machine_learning/put_datafeed.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/put_datafeed.rb
@@ -23,6 +23,15 @@ module ElasticsearchServerless
     module MachineLearning
       module Actions
         # Instantiates a datafeed.
+        # Datafeeds retrieve data from Elasticsearch for analysis by an anomaly detection job.
+        # You can associate only one datafeed with each anomaly detection job.
+        # The datafeed contains a query that runs at a defined interval (`frequency`).
+        # If you are concerned about delayed data, you can add a delay (`query_delay') at each interval.
+        # When Elasticsearch security features are enabled, your datafeed remembers which roles the user who created it had
+        # at the time of creation and runs the query using those same roles. If you provide secondary authorization headers,
+        # those credentials are used instead.
+        # You must use Kibana, this API, or the create anomaly detection jobs API to create a datafeed. Do not add a datafeed
+        # directly to the `.ml-config` index. Do not give users `write` privileges on the `.ml-config` index.
         #
         # @option arguments [String] :datafeed_id A numerical character string that uniquely identifies the datafeed. This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric characters. (*Required*)
         # @option arguments [Boolean] :allow_no_indices If true, wildcard indices expressions that resolve into no concrete indices are ignored. This includes the +_all+ string or when no indices are specified. Server default: true.

--- a/lib/elasticsearch-serverless/api/machine_learning/put_datafeed.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/put_datafeed.rb
@@ -25,13 +25,13 @@ module ElasticsearchServerless
         # Instantiates a datafeed.
         # Datafeeds retrieve data from Elasticsearch for analysis by an anomaly detection job.
         # You can associate only one datafeed with each anomaly detection job.
-        # The datafeed contains a query that runs at a defined interval (`frequency`).
-        # If you are concerned about delayed data, you can add a delay (`query_delay') at each interval.
+        # The datafeed contains a query that runs at a defined interval (+frequency+).
+        # If you are concerned about delayed data, you can add a delay (+query_delay') at each interval.
         # When Elasticsearch security features are enabled, your datafeed remembers which roles the user who created it had
         # at the time of creation and runs the query using those same roles. If you provide secondary authorization headers,
         # those credentials are used instead.
         # You must use Kibana, this API, or the create anomaly detection jobs API to create a datafeed. Do not add a datafeed
-        # directly to the `.ml-config` index. Do not give users `write` privileges on the `.ml-config` index.
+        # directly to the +.ml-config+ index. Do not give users +write+ privileges on the +.ml-config+ index.
         #
         # @option arguments [String] :datafeed_id A numerical character string that uniquely identifies the datafeed. This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric characters. (*Required*)
         # @option arguments [Boolean] :allow_no_indices If true, wildcard indices expressions that resolve into no concrete indices are ignored. This includes the +_all+ string or when no indices are specified. Server default: true.

--- a/lib/elasticsearch-serverless/api/machine_learning/put_filter.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/put_filter.rb
@@ -24,7 +24,7 @@ module ElasticsearchServerless
       module Actions
         # Instantiates a filter.
         # A filter contains a list of strings. It can be used by one or more anomaly detection jobs.
-        # Specifically, filters are referenced in the `custom_rules` property of detector configuration objects.
+        # Specifically, filters are referenced in the +custom_rules+ property of detector configuration objects.
         #
         # @option arguments [String] :filter_id A string that uniquely identifies a filter. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/machine_learning/put_filter.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/put_filter.rb
@@ -23,6 +23,8 @@ module ElasticsearchServerless
     module MachineLearning
       module Actions
         # Instantiates a filter.
+        # A filter contains a list of strings. It can be used by one or more anomaly detection jobs.
+        # Specifically, filters are referenced in the `custom_rules` property of detector configuration objects.
         #
         # @option arguments [String] :filter_id A string that uniquely identifies a filter. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/machine_learning/put_job.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/put_job.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Instantiates an anomaly detection job.
+        # Instantiates an anomaly detection job. If you include a `datafeed_config`, you must have read index privileges on the source index.
         #
         # @option arguments [String] :job_id The identifier for the anomaly detection job. This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric characters. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/machine_learning/put_job.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/put_job.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Instantiates an anomaly detection job. If you include a `datafeed_config`, you must have read index privileges on the source index.
+        # Instantiates an anomaly detection job. If you include a +datafeed_config+, you must have read index privileges on the source index.
         #
         # @option arguments [String] :job_id The identifier for the anomaly detection job. This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric characters. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/machine_learning/put_trained_model.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/put_trained_model.rb
@@ -22,10 +22,11 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Creates an inference trained model.
+        # Enables you to supply a trained model that is not created by data frame analytics.
         #
         # @option arguments [String] :model_id The unique identifier of the trained model. (*Required*)
         # @option arguments [Boolean] :defer_definition_decompression If set to +true+ and a +compressed_definition+ is provided, the request defers definition decompression and skips relevant validations.
+        # @option arguments [Boolean] :wait_for_completion Whether to wait for all child operations (e.g. model download) to complete.
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body request body
         #

--- a/lib/elasticsearch-serverless/api/machine_learning/put_trained_model_alias.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/put_trained_model_alias.rb
@@ -22,7 +22,22 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Creates a new model alias (or reassigns an existing one) to refer to the trained model
+        # Creates or updates a trained model alias. A trained model alias is a logical
+        # name used to reference a single trained model.
+        # You can use aliases instead of trained model identifiers to make it easier to
+        # reference your models. For example, you can use aliases in inference
+        # aggregations and processors.
+        # An alias must be unique and refer to only a single trained model. However,
+        # you can have multiple aliases for each trained model.
+        # If you use this API to update an alias such that it references a different
+        # trained model ID and the model uses a different type of data frame analytics,
+        # an error occurs. For example, this situation occurs if you have a trained
+        # model for regression analysis and a trained model for classification
+        # analysis; you cannot reassign an alias from one type of trained model to
+        # another.
+        # If you use this API to update an alias and there are very few input fields in
+        # common between the old and new trained models for the model alias, the API
+        # returns a warning.
         #
         # @option arguments [String] :model_alias The alias to create or update. This value cannot end in numbers. (*Required*)
         # @option arguments [String] :model_id The identifier for the trained model that the alias refers to. (*Required*)

--- a/lib/elasticsearch-serverless/api/machine_learning/put_trained_model_definition_part.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/put_trained_model_definition_part.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Creates part of a trained model definition
+        # Creates part of a trained model definition.
         #
         # @option arguments [String] :model_id The unique identifier of the trained model. (*Required*)
         # @option arguments [Integer] :part The definition part number. When the definition is loaded for inference the definition parts are streamed in the order of their part number. The first part must be +0+ and the final part must be +total_parts - 1+. (*Required*)

--- a/lib/elasticsearch-serverless/api/machine_learning/put_trained_model_vocabulary.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/put_trained_model_vocabulary.rb
@@ -22,7 +22,9 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Creates a trained model vocabulary
+        # Creates a trained model vocabulary.
+        # This API is supported only for natural language processing (NLP) models.
+        # The vocabulary is stored in the index as described in `inference_config.*.vocabulary` of the trained model definition.
         #
         # @option arguments [String] :model_id The unique identifier of the trained model. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/machine_learning/put_trained_model_vocabulary.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/put_trained_model_vocabulary.rb
@@ -24,7 +24,7 @@ module ElasticsearchServerless
       module Actions
         # Creates a trained model vocabulary.
         # This API is supported only for natural language processing (NLP) models.
-        # The vocabulary is stored in the index as described in `inference_config.*.vocabulary` of the trained model definition.
+        # The vocabulary is stored in the index as described in +inference_config.*.vocabulary+ of the trained model definition.
         #
         # @option arguments [String] :model_id The unique identifier of the trained model. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/machine_learning/reset_job.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/reset_job.rb
@@ -22,7 +22,11 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Resets an existing anomaly detection job.
+        # Resets an anomaly detection job.
+        # All model state and results are deleted. The job is ready to start over as if
+        # it had just been created.
+        # It is not currently possible to reset multiple jobs using wildcards or a
+        # comma separated list.
         #
         # @option arguments [String] :job_id The ID of the job to reset. (*Required*)
         # @option arguments [Boolean] :wait_for_completion Should this request wait until the operation has completed before returning. Server default: true.

--- a/lib/elasticsearch-serverless/api/machine_learning/start_data_frame_analytics.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/start_data_frame_analytics.rb
@@ -23,6 +23,17 @@ module ElasticsearchServerless
     module MachineLearning
       module Actions
         # Starts a data frame analytics job.
+        # A data frame analytics job can be started and stopped multiple times
+        # throughout its lifecycle.
+        # If the destination index does not exist, it is created automatically the
+        # first time you start the data frame analytics job. The
+        # `index.number_of_shards` and `index.number_of_replicas` settings for the
+        # destination index are copied from the source index. If there are multiple
+        # source indices, the destination index copies the highest setting values. The
+        # mappings for the destination index are also copied from the source indices.
+        # If there are any mapping conflicts, the job fails to start.
+        # If the destination index exists, it is used as is. You can therefore set up
+        # the destination index in advance with custom settings and mappings.
         #
         # @option arguments [String] :id Identifier for the data frame analytics job. This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric characters. (*Required*)
         # @option arguments [Time] :timeout Controls the amount of time to wait until the data frame analytics job starts. Server default: 20s.

--- a/lib/elasticsearch-serverless/api/machine_learning/start_data_frame_analytics.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/start_data_frame_analytics.rb
@@ -27,7 +27,7 @@ module ElasticsearchServerless
         # throughout its lifecycle.
         # If the destination index does not exist, it is created automatically the
         # first time you start the data frame analytics job. The
-        # `index.number_of_shards` and `index.number_of_replicas` settings for the
+        # +index.number_of_shards+ and +index.number_of_replicas+ settings for the
         # destination index are copied from the source index. If there are multiple
         # source indices, the destination index copies the highest setting values. The
         # mappings for the destination index are also copied from the source indices.

--- a/lib/elasticsearch-serverless/api/machine_learning/start_datafeed.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/start_datafeed.rb
@@ -24,6 +24,18 @@ module ElasticsearchServerless
       module Actions
         # Starts one or more datafeeds.
         #
+        # A datafeed must be started in order to retrieve data from Elasticsearch. A datafeed can be started and stopped
+        # multiple times throughout its lifecycle.
+        #
+        # Before you can start a datafeed, the anomaly detection job must be open. Otherwise, an error occurs.
+        #
+        # If you restart a stopped datafeed, it continues processing input data from the next millisecond after it was stopped.
+        # If new data was indexed for that exact millisecond between stopping and starting, it will be ignored.
+        #
+        # When Elasticsearch security features are enabled, your datafeed remembers which roles the last user to create or
+        # update it had at the time of creation or update and runs the query using those same roles. If you provided secondary
+        # authorization headers when you created or updated the datafeed, those credentials are used instead.
+        #
         # @option arguments [String] :datafeed_id A numerical character string that uniquely identifies the datafeed. This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric characters. (*Required*)
         # @option arguments [String, Time] :end The time that the datafeed should end, which can be specified by using one of the following formats:  * ISO 8601 format with milliseconds, for example +2017-01-22T06:00:00.000Z+ * ISO 8601 format without milliseconds, for example +2017-01-22T06:00:00+00:00+ * Milliseconds since the epoch, for example +1485061200000+  Date-time arguments using either of the ISO 8601 formats must have a time zone designator, where +Z+ is accepted as an abbreviation for UTC time. When a URL is expected (for example, in browsers), the +++ used in time zone designators must be encoded as +%2B+. The end time value is exclusive. If you do not specify an end time, the datafeed runs continuously.
         # @option arguments [String, Time] :start The time that the datafeed should begin, which can be specified by using the same formats as the +end+ parameter. This value is inclusive. If you do not specify a start time and the datafeed is associated with a new anomaly detection job, the analysis starts from the earliest time for which data is available. If you restart a stopped datafeed and specify a start value that is earlier than the timestamp of the latest processed record, the datafeed continues from 1 millisecond after the timestamp of the latest processed record.

--- a/lib/elasticsearch-serverless/api/machine_learning/start_trained_model_deployment.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/start_trained_model_deployment.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Start a trained model deployment.
+        # Starts a trained model deployment, which allocates the model to every machine learning node.
         #
         # @option arguments [String] :model_id The unique identifier of the trained model. Currently, only PyTorch models are supported. (*Required*)
         # @option arguments [Integer, String] :cache_size The inference cache size (in memory outside the JVM heap) per node for the model. The default value is the same size as the +model_size_bytes+. To disable the cache, +0b+ can be provided.

--- a/lib/elasticsearch-serverless/api/machine_learning/stop_data_frame_analytics.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/stop_data_frame_analytics.rb
@@ -23,6 +23,8 @@ module ElasticsearchServerless
     module MachineLearning
       module Actions
         # Stops one or more data frame analytics jobs.
+        # A data frame analytics job can be started and stopped multiple times
+        # throughout its lifecycle.
         #
         # @option arguments [String] :id Identifier for the data frame analytics job. This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric characters. (*Required*)
         # @option arguments [Boolean] :allow_no_match Specifies what to do when the request:  1. Contains wildcard expressions and there are no data frame analytics jobs that match. 2. Contains the _all string or no identifiers and there are no matches. 3. Contains wildcard expressions and there are only partial matches.  The default value is true, which returns an empty data_frame_analytics array when there are no matches and the subset of results when there are partial matches. If this parameter is false, the request returns a 404 status code when there are no matches or only partial matches. Server default: true.

--- a/lib/elasticsearch-serverless/api/machine_learning/stop_datafeed.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/stop_datafeed.rb
@@ -23,6 +23,8 @@ module ElasticsearchServerless
     module MachineLearning
       module Actions
         # Stops one or more datafeeds.
+        # A datafeed that is stopped ceases to retrieve data from Elasticsearch. A datafeed can be started and stopped
+        # multiple times throughout its lifecycle.
         #
         # @option arguments [String] :datafeed_id Identifier for the datafeed. You can stop multiple datafeeds in a single API request by using a comma-separated list of datafeeds or a wildcard expression. You can close all datafeeds by using +_all+ or by specifying +*+ as the identifier. (*Required*)
         # @option arguments [Boolean] :allow_no_match Specifies what to do when the request:  * Contains wildcard expressions and there are no datafeeds that match. * Contains the +_all+ string or no identifiers and there are no matches. * Contains wildcard expressions and there are only partial matches.  If +true+, the API returns an empty datafeeds array when there are no matches and the subset of results when there are partial matches. If +false+, the API returns a 404 status code when there are no matches or only partial matches. Server default: true.

--- a/lib/elasticsearch-serverless/api/machine_learning/stop_trained_model_deployment.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/stop_trained_model_deployment.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Stop a trained model deployment.
+        # Stops a trained model deployment.
         #
         # @option arguments [String] :model_id The unique identifier of the trained model. (*Required*)
         # @option arguments [Boolean] :allow_no_match Specifies what to do when the request: contains wildcard expressions and there are no deployments that match; contains the  +_all+ string or no identifiers and there are no matches; or contains wildcard expressions and there are only partial matches. By default, it returns an empty array when there are no matches and the subset of results when there are partial matches. If +false+, the request returns a 404 status code when there are no matches or only partial matches. Server default: true.

--- a/lib/elasticsearch-serverless/api/machine_learning/update_data_frame_analytics.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/update_data_frame_analytics.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Updates certain properties of a data frame analytics job.
+        # Updates an existing data frame analytics job.
         #
         # @option arguments [String] :id Identifier for the data frame analytics job. This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric characters. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/machine_learning/update_datafeed.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/update_datafeed.rb
@@ -22,7 +22,11 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Updates certain properties of a datafeed.
+        # Updates the properties of a datafeed.
+        # You must stop and start the datafeed for the changes to be applied.
+        # When Elasticsearch security features are enabled, your datafeed remembers which roles the user who updated it had at
+        # the time of the update and runs the query using those same roles. If you provide secondary authorization headers,
+        # those credentials are used instead.
         #
         # @option arguments [String] :datafeed_id A numerical character string that uniquely identifies the datafeed. This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric characters. (*Required*)
         # @option arguments [Boolean] :allow_no_indices If +true+, wildcard indices expressions that resolve into no concrete indices are ignored. This includes the +_all+ string or when no indices are specified. Server default: true.

--- a/lib/elasticsearch-serverless/api/machine_learning/update_filter.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/update_filter.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module MachineLearning
       module Actions
-        # Updates the description of a filter, adds items, or removes items.
+        # Updates the description of a filter, adds items, or removes items from the list.
         #
         # @option arguments [String] :filter_id A string that uniquely identifies a filter. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/mget.rb
+++ b/lib/elasticsearch-serverless/api/mget.rb
@@ -24,6 +24,7 @@ module ElasticsearchServerless
       # Allows to get multiple documents in one request.
       #
       # @option arguments [String] :index Name of the index to retrieve documents from when +ids+ are specified, or when a document in the +docs+ array does not specify an index.
+      # @option arguments [Boolean] :force_synthetic_source Should this request force synthetic _source? Use this to test if the mapping supports synthetic _source and to get a sense of the worst case performance. Fetches with this enabled will be slower the enabling synthetic source natively in the index.
       # @option arguments [String] :preference Specifies the node or shard the operation should be performed on. Random by default.
       # @option arguments [Boolean] :realtime If +true+, the request is real-time as opposed to near-real-time. Server default: true.
       # @option arguments [Boolean] :refresh If +true+, the request refreshes relevant shards before retrieving documents.

--- a/lib/elasticsearch-serverless/api/msearch_template.rb
+++ b/lib/elasticsearch-serverless/api/msearch_template.rb
@@ -21,7 +21,7 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Allows to execute several search template operations in one request.
+      # Runs multiple templated searches with a single request.
       #
       # @option arguments [String, Array] :index Comma-separated list of data streams, indices, and aliases to search. Supports wildcards (+*+). To search all data streams and indices, omit this parameter or use +*+.
       # @option arguments [Boolean] :ccs_minimize_roundtrips If +true+, network round-trips are minimized for cross-cluster search requests. Server default: true.

--- a/lib/elasticsearch-serverless/api/open_point_in_time.rb
+++ b/lib/elasticsearch-serverless/api/open_point_in_time.rb
@@ -25,7 +25,7 @@ module ElasticsearchServerless
       # which is called point in time. Elasticsearch pit (point in time) is a lightweight view into the
       # state of the data as it existed when initiated. In some cases, it’s preferred to perform multiple
       # search requests using the same point in time. For example, if refreshes happen between
-      # `search_after` requests, then the results of those requests might not be consistent as changes happening
+      # +search_after+ requests, then the results of those requests might not be consistent as changes happening
       # between searches are only visible to the more recent point in time.
       #
       # @option arguments [String, Array] :index A comma-separated list of index names to open point in time; use +_all+ or empty string to perform the operation on all indices (*Required*)

--- a/lib/elasticsearch-serverless/api/open_point_in_time.rb
+++ b/lib/elasticsearch-serverless/api/open_point_in_time.rb
@@ -21,7 +21,12 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Open a point in time that can be used in subsequent searches
+      # A search request by default executes against the most recent visible data of the target indices,
+      # which is called point in time. Elasticsearch pit (point in time) is a lightweight view into the
+      # state of the data as it existed when initiated. In some cases, it’s preferred to perform multiple
+      # search requests using the same point in time. For example, if refreshes happen between
+      # `search_after` requests, then the results of those requests might not be consistent as changes happening
+      # between searches are only visible to the more recent point in time.
       #
       # @option arguments [String, Array] :index A comma-separated list of index names to open point in time; use +_all+ or empty string to perform the operation on all indices (*Required*)
       # @option arguments [Time] :keep_alive Extends the time to live of the corresponding point in time. (*Required*)

--- a/lib/elasticsearch-serverless/api/put_script.rb
+++ b/lib/elasticsearch-serverless/api/put_script.rb
@@ -21,7 +21,7 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Creates or updates a script.
+      # Creates or updates a stored script or search template.
       #
       # @option arguments [String] :id Identifier for the stored script or search template. Must be unique within the cluster. (*Required*)
       # @option arguments [String] :context Context in which the script or search template should run. To prevent errors, the API immediately compiles the script or template in this context.

--- a/lib/elasticsearch-serverless/api/query_ruleset/get.rb
+++ b/lib/elasticsearch-serverless/api/query_ruleset/get.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module QueryRuleset
       module Actions
-        # Returns the details about a query ruleset.
+        # Returns the details about a query ruleset
         # This functionality is Experimental and may be changed or removed
         # completely in a future release. Elastic will take a best effort approach
         # to fix any issues, but experimental features are not subject to the

--- a/lib/elasticsearch-serverless/api/query_ruleset/list.rb
+++ b/lib/elasticsearch-serverless/api/query_ruleset/list.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module QueryRuleset
       module Actions
-        # Lists query rulesets.
+        # Returns summarized information about existing query rulesets.
         # This functionality is Experimental and may be changed or removed
         # completely in a future release. Elastic will take a best effort approach
         # to fix any issues, but experimental features are not subject to the

--- a/lib/elasticsearch-serverless/api/rank_eval.rb
+++ b/lib/elasticsearch-serverless/api/rank_eval.rb
@@ -21,7 +21,7 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Allows to evaluate the quality of ranked search results over a set of typical search queries
+      # Enables you to evaluate the quality of ranked search results over a set of typical search queries.
       #
       # @option arguments [String, Array] :index Comma-separated list of data streams, indices, and index aliases used to limit the request. Wildcard (+*+) expressions are supported. To target all data streams and indices in a cluster, omit this parameter or use +_all+ or +*+.
       # @option arguments [Boolean] :allow_no_indices If +false+, the request returns an error if any wildcard expression, index alias, or +_all+ value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request targeting +foo*,bar*+ returns an error if an index starts with +foo+ but no index starts with +bar+. Server default: true.

--- a/lib/elasticsearch-serverless/api/render_search_template.rb
+++ b/lib/elasticsearch-serverless/api/render_search_template.rb
@@ -21,7 +21,7 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Allows to use the Mustache language to pre-render a search definition.
+      # Renders a search template as a search request body.
       #
       # @option arguments [String] :id ID of the search template to render. If no +source+ is specified, this or the +id+ request body parameter is required.
       # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/scripts_painless_execute.rb
+++ b/lib/elasticsearch-serverless/api/scripts_painless_execute.rb
@@ -21,7 +21,7 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Allows an arbitrary script to be executed and a result to be returned
+      # Runs a script and returns a result.
       # This functionality is Experimental and may be changed or removed
       # completely in a future release. Elastic will take a best effort approach
       # to fix any issues, but experimental features are not subject to the

--- a/lib/elasticsearch-serverless/api/search.rb
+++ b/lib/elasticsearch-serverless/api/search.rb
@@ -21,7 +21,9 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Returns results matching a query.
+      # Returns search hits that match the query defined in the request.
+      # You can provide search queries using the `q` query string parameter or the request body.
+      # If both are specified, only the query parameter is used.
       #
       # @option arguments [String, Array] :index Comma-separated list of data streams, indices, and aliases to search. Supports wildcards (+*+). To search all data streams and indices, omit this parameter or use +*+ or +_all+.
       # @option arguments [Boolean] :allow_no_indices If +false+, the request returns an error if any wildcard expression, index alias, or +_all+ value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request targeting +foo*,bar*+ returns an error if an index starts with +foo+ but no index starts with +bar+. Server default: true.
@@ -67,6 +69,7 @@ module ElasticsearchServerless
       # @option arguments [Integer] :size Defines the number of hits to return. By default, you cannot page through more than 10,000 hits using the +from+ and +size+ parameters. To page through more hits, use the +search_after+ parameter. Server default: 10.
       # @option arguments [Integer] :from Starting document offset. Needs to be non-negative. By default, you cannot page through more than 10,000 hits using the +from+ and +size+ parameters. To page through more hits, use the +search_after+ parameter. Server default: 0.
       # @option arguments [String] :sort A comma-separated list of <field>:<direction> pairs.
+      # @option arguments [Boolean] :force_synthetic_source Should this request force synthetic _source? Use this to test if the mapping supports synthetic _source and to get a sense of the worst case performance. Fetches with this enabled will be slower the enabling synthetic source natively in the index.
       # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [Hash] :body request body
       #

--- a/lib/elasticsearch-serverless/api/search.rb
+++ b/lib/elasticsearch-serverless/api/search.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Actions
       # Returns search hits that match the query defined in the request.
-      # You can provide search queries using the `q` query string parameter or the request body.
+      # You can provide search queries using the +q+ query string parameter or the request body.
       # If both are specified, only the query parameter is used.
       #
       # @option arguments [String, Array] :index Comma-separated list of data streams, indices, and aliases to search. Supports wildcards (+*+). To search all data streams and indices, omit this parameter or use +*+ or +_all+.

--- a/lib/elasticsearch-serverless/api/search_application/get.rb
+++ b/lib/elasticsearch-serverless/api/search_application/get.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module SearchApplication
       module Actions
-        # Returns the details about a search application.
+        # Returns the details about a search application
         # This functionality is in Beta and is subject to change. The design and
         # code is less mature than official GA features and is being provided
         # as-is with no warranties. Beta features are not subject to the support

--- a/lib/elasticsearch-serverless/api/search_application/search.rb
+++ b/lib/elasticsearch-serverless/api/search_application/search.rb
@@ -22,13 +22,14 @@ module ElasticsearchServerless
   module API
     module SearchApplication
       module Actions
-        # Perform a search against a search application
+        # Perform a search against a search application.
         # This functionality is in Beta and is subject to change. The design and
         # code is less mature than official GA features and is being provided
         # as-is with no warranties. Beta features are not subject to the support
         # SLA of official GA features.
         #
         # @option arguments [String] :name The name of the search application to be searched. (*Required*)
+        # @option arguments [Boolean] :typed_keys Determines whether aggregation names are prefixed by their respective types in the response.
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body request body
         #
@@ -51,7 +52,7 @@ module ElasticsearchServerless
                    end
 
           path   = "_application/search_application/#{Utils.listify(_name)}/_search"
-          params = {}
+          params = Utils.process_params(arguments)
 
           ElasticsearchServerless::API::Response.new(
             perform_request(method, path, params, body, headers)

--- a/lib/elasticsearch-serverless/api/search_template.rb
+++ b/lib/elasticsearch-serverless/api/search_template.rb
@@ -21,7 +21,7 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Allows to use the Mustache language to pre-render a search definition.
+      # Runs a search with a search template.
       #
       # @option arguments [String, Array] :index Comma-separated list of data streams, indices, and aliases to search. Supports wildcards (*).
       # @option arguments [Boolean] :allow_no_indices If +false+, the request returns an error if any wildcard expression, index alias, or +_all+ value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request targeting +foo*,bar*+ returns an error if an index starts with +foo+ but no index starts with +bar+. Server default: true.

--- a/lib/elasticsearch-serverless/api/security/authenticate.rb
+++ b/lib/elasticsearch-serverless/api/security/authenticate.rb
@@ -22,7 +22,9 @@ module ElasticsearchServerless
   module API
     module Security
       module Actions
-        # Enables authentication as a user and retrieve information about the authenticated user.
+        # Enables you to submit a request with a basic auth header to authenticate a user and retrieve information about the authenticated user.
+        # A successful call returns a JSON structure that shows user information such as their username, the roles that are assigned to the user, any assigned metadata, and information about the realms that authenticated and authorized the user.
+        # If the user cannot be authenticated, this API returns a 401 status code.
         #
         # @option arguments [Hash] :headers Custom HTTP headers
         #

--- a/lib/elasticsearch-serverless/api/security/create_api_key.rb
+++ b/lib/elasticsearch-serverless/api/security/create_api_key.rb
@@ -23,6 +23,9 @@ module ElasticsearchServerless
     module Security
       module Actions
         # Creates an API key for access without requiring basic authentication.
+        # A successful request returns a JSON structure that contains the API key, its unique id, and its name.
+        # If applicable, it also returns expiration information for the API key in milliseconds.
+        # NOTE: By default, API keys never expire. You can specify expiration information when you create the API keys.
         #
         # @option arguments [String] :refresh If +true+ (the default) then refresh the affected shards to make this operation visible to search, if +wait_for+ then wait for a refresh to make this operation visible to search, if +false+ then do nothing with refreshes.
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/security/get_api_key.rb
+++ b/lib/elasticsearch-serverless/api/security/get_api_key.rb
@@ -23,8 +23,8 @@ module ElasticsearchServerless
     module Security
       module Actions
         # Retrieves information for one or more API keys.
-        # NOTE: If you have only the `manage_own_api_key` privilege, this API returns only the API keys that you own.
-        # If you have `read_security`, `manage_api_key` or greater privileges (including `manage_security`), this API returns all API keys regardless of ownership.
+        # NOTE: If you have only the +manage_own_api_key+ privilege, this API returns only the API keys that you own.
+        # If you have +read_security+, +manage_api_key+ or greater privileges (including +manage_security+), this API returns all API keys regardless of ownership.
         #
         # @option arguments [String] :id An API key id. This parameter cannot be used with any of +name+, +realm_name+ or +username+.
         # @option arguments [String] :name An API key name. This parameter cannot be used with any of +id+, +realm_name+ or +username+. It supports prefix search with wildcard.

--- a/lib/elasticsearch-serverless/api/security/get_api_key.rb
+++ b/lib/elasticsearch-serverless/api/security/get_api_key.rb
@@ -23,6 +23,8 @@ module ElasticsearchServerless
     module Security
       module Actions
         # Retrieves information for one or more API keys.
+        # NOTE: If you have only the `manage_own_api_key` privilege, this API returns only the API keys that you own.
+        # If you have `read_security`, `manage_api_key` or greater privileges (including `manage_security`), this API returns all API keys regardless of ownership.
         #
         # @option arguments [String] :id An API key id. This parameter cannot be used with any of +name+, +realm_name+ or +username+.
         # @option arguments [String] :name An API key name. This parameter cannot be used with any of +id+, +realm_name+ or +username+. It supports prefix search with wildcard.
@@ -30,6 +32,8 @@ module ElasticsearchServerless
         # @option arguments [String] :realm_name The name of an authentication realm. This parameter cannot be used with either +id+ or +name+ or when +owner+ flag is set to +true+.
         # @option arguments [String] :username The username of a user. This parameter cannot be used with either +id+ or +name+ or when +owner+ flag is set to +true+.
         # @option arguments [Boolean] :with_limited_by Return the snapshot of the owner user's role descriptors associated with the API key. An API key's actual permission is the intersection of its assigned role descriptors and the owner user's role descriptors.
+        # @option arguments [Boolean] :active_only A boolean flag that can be used to query API keys that are currently active. An API key is considered active if it is neither invalidated, nor expired at query time. You can specify this together with other parameters such as +owner+ or +name+. If +active_only+ is false, the response will include both active and inactive (expired or invalidated) keys.
+        # @option arguments [Boolean] :with_profile_uid Determines whether to also retrieve the profile uid, for the API key owner principal, if it exists.
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-api-key.html

--- a/lib/elasticsearch-serverless/api/security/invalidate_api_key.rb
+++ b/lib/elasticsearch-serverless/api/security/invalidate_api_key.rb
@@ -23,6 +23,12 @@ module ElasticsearchServerless
     module Security
       module Actions
         # Invalidates one or more API keys.
+        # The `manage_api_key` privilege allows deleting any API keys.
+        # The `manage_own_api_key` only allows deleting API keys that are owned by the user.
+        # In addition, with the `manage_own_api_key` privilege, an invalidation request must be issued in one of the three formats:
+        # - Set the parameter `owner=true`.
+        # - Or, set both `username` and `realm_name` to match the user’s identity.
+        # - Or, if the request is issued by an API key, i.e. an API key invalidates itself, specify its ID in the `ids` field.
         #
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body request body

--- a/lib/elasticsearch-serverless/api/security/invalidate_api_key.rb
+++ b/lib/elasticsearch-serverless/api/security/invalidate_api_key.rb
@@ -23,12 +23,12 @@ module ElasticsearchServerless
     module Security
       module Actions
         # Invalidates one or more API keys.
-        # The `manage_api_key` privilege allows deleting any API keys.
-        # The `manage_own_api_key` only allows deleting API keys that are owned by the user.
-        # In addition, with the `manage_own_api_key` privilege, an invalidation request must be issued in one of the three formats:
-        # - Set the parameter `owner=true`.
-        # - Or, set both `username` and `realm_name` to match the user’s identity.
-        # - Or, if the request is issued by an API key, i.e. an API key invalidates itself, specify its ID in the `ids` field.
+        # The +manage_api_key+ privilege allows deleting any API keys.
+        # The +manage_own_api_key+ only allows deleting API keys that are owned by the user.
+        # In addition, with the +manage_own_api_key+ privilege, an invalidation request must be issued in one of the three formats:
+        # - Set the parameter +owner=true+.
+        # - Or, set both +username+ and +realm_name+ to match the user’s identity.
+        # - Or, if the request is issued by an API key, i.e. an API key invalidates itself, specify its ID in the +ids+ field.
         #
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body request body

--- a/lib/elasticsearch-serverless/api/security/query_api_keys.rb
+++ b/lib/elasticsearch-serverless/api/security/query_api_keys.rb
@@ -22,9 +22,11 @@ module ElasticsearchServerless
   module API
     module Security
       module Actions
-        # Retrieves information for API keys using a subset of query DSL
+        # Retrieves information for API keys in a paginated manner. You can optionally filter the results with a query.
         #
-        # @option arguments [Boolean] :with_limited_by Return the snapshot of the owner user's role descriptors associated with the API key.  An API key's actual permission is the intersection of its assigned role descriptors and the owner user's role descriptors.
+        # @option arguments [Boolean] :with_limited_by Return the snapshot of the owner user's role descriptors associated with the API key. An API key's actual permission is the intersection of its assigned role descriptors and the owner user's role descriptors.
+        # @option arguments [Boolean] :with_profile_uid Determines whether to also retrieve the profile uid, for the API key owner principal, if it exists.
+        # @option arguments [Boolean] :typed_keys Determines whether aggregation names are prefixed by their respective types in the response.
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body request body
         #

--- a/lib/elasticsearch-serverless/api/synonyms/put_synonym.rb
+++ b/lib/elasticsearch-serverless/api/synonyms/put_synonym.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Synonyms
       module Actions
-        # Creates or updates a synonyms set
+        # Creates or updates a synonym set.
         #
         # @option arguments [String] :id The id of the synonyms set to be created or updated (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/transform/delete_transform.rb
+++ b/lib/elasticsearch-serverless/api/transform/delete_transform.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Transform
       module Actions
-        # Deletes an existing transform.
+        # Deletes a transform.
         #
         # @option arguments [String] :transform_id Identifier for the transform. (*Required*)
         # @option arguments [Boolean] :force If this value is false, the transform must be stopped before it can be deleted. If true, the transform is deleted regardless of its current state.

--- a/lib/elasticsearch-serverless/api/transform/preview_transform.rb
+++ b/lib/elasticsearch-serverless/api/transform/preview_transform.rb
@@ -24,6 +24,10 @@ module ElasticsearchServerless
       module Actions
         # Previews a transform.
         #
+        # It returns a maximum of 100 results. The calculations are based on all the current data in the source index. It also
+        # generates a list of mappings and settings for the destination index. These values are determined based on the field
+        # types of the source index and the transform aggregations.
+        #
         # @option arguments [String] :transform_id Identifier for the transform to preview. If you specify this path parameter, you cannot provide transform configuration details in the request body.
         # @option arguments [Time] :timeout Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error. Server default: 30s.
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/transform/put_transform.rb
+++ b/lib/elasticsearch-serverless/api/transform/put_transform.rb
@@ -22,7 +22,27 @@ module ElasticsearchServerless
   module API
     module Transform
       module Actions
-        # Instantiates a transform.
+        # Creates a transform.
+        #
+        # A transform copies data from source indices, transforms it, and persists it into an entity-centric destination index. You can also think of the destination index as a two-dimensional tabular data structure (known as
+        # a data frame). The ID for each document in the data frame is generated from a hash of the entity, so there is a
+        # unique row per entity.
+        #
+        # You must choose either the latest or pivot method for your transform; you cannot use both in a single transform. If
+        # you choose to use the pivot method for your transform, the entities are defined by the set of `group_by` fields in
+        # the pivot object. If you choose to use the latest method, the entities are defined by the `unique_key` field values
+        # in the latest object.
+        #
+        # You must have `create_index`, `index`, and `read` privileges on the destination index and `read` and
+        # `view_index_metadata` privileges on the source indices. When Elasticsearch security features are enabled, the
+        # transform remembers which roles the user that created it had at the time of creation and uses those same roles. If
+        # those roles do not have the required privileges on the source and destination indices, the transform fails when it
+        # attempts unauthorized operations.
+        #
+        # NOTE: You must use Kibana or this API to create a transform. Do not add a transform directly into any
+        # `.transform-internal*` indices using the Elasticsearch index API. If Elasticsearch security features are enabled, do
+        # not give users any privileges on `.transform-internal*` indices. If you used transforms prior to 7.5, also do not
+        # give users any privileges on `.data-frame-internal*` indices.
         #
         # @option arguments [String] :transform_id Identifier for the transform. This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It has a 64 character limit and must start and end with alphanumeric characters. (*Required*)
         # @option arguments [Boolean] :defer_validation When the transform is created, a series of validations occur to ensure its success. For example, there is a check for the existence of the source indices and a check that the destination index is not part of the source index pattern. You can use this parameter to skip the checks, for example when the source index does not exist until after the transform is created. The validations are always run when you start the transform, however, with the exception of privilege checks.

--- a/lib/elasticsearch-serverless/api/transform/put_transform.rb
+++ b/lib/elasticsearch-serverless/api/transform/put_transform.rb
@@ -29,20 +29,20 @@ module ElasticsearchServerless
         # unique row per entity.
         #
         # You must choose either the latest or pivot method for your transform; you cannot use both in a single transform. If
-        # you choose to use the pivot method for your transform, the entities are defined by the set of `group_by` fields in
-        # the pivot object. If you choose to use the latest method, the entities are defined by the `unique_key` field values
+        # you choose to use the pivot method for your transform, the entities are defined by the set of +group_by+ fields in
+        # the pivot object. If you choose to use the latest method, the entities are defined by the +unique_key+ field values
         # in the latest object.
         #
-        # You must have `create_index`, `index`, and `read` privileges on the destination index and `read` and
-        # `view_index_metadata` privileges on the source indices. When Elasticsearch security features are enabled, the
+        # You must have +create_index+, +index+, and +read+ privileges on the destination index and +read+ and
+        # +view_index_metadata+ privileges on the source indices. When Elasticsearch security features are enabled, the
         # transform remembers which roles the user that created it had at the time of creation and uses those same roles. If
         # those roles do not have the required privileges on the source and destination indices, the transform fails when it
         # attempts unauthorized operations.
         #
         # NOTE: You must use Kibana or this API to create a transform. Do not add a transform directly into any
-        # `.transform-internal*` indices using the Elasticsearch index API. If Elasticsearch security features are enabled, do
-        # not give users any privileges on `.transform-internal*` indices. If you used transforms prior to 7.5, also do not
-        # give users any privileges on `.data-frame-internal*` indices.
+        # +.transform-internal*+ indices using the Elasticsearch index API. If Elasticsearch security features are enabled, do
+        # not give users any privileges on +.transform-internal*+ indices. If you used transforms prior to 7.5, also do not
+        # give users any privileges on +.data-frame-internal*+ indices.
         #
         # @option arguments [String] :transform_id Identifier for the transform. This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It has a 64 character limit and must start and end with alphanumeric characters. (*Required*)
         # @option arguments [Boolean] :defer_validation When the transform is created, a series of validations occur to ensure its success. For example, there is a check for the existence of the source indices and a check that the destination index is not part of the source index pattern. You can use this parameter to skip the checks, for example when the source index does not exist until after the transform is created. The validations are always run when you start the transform, however, with the exception of privilege checks.

--- a/lib/elasticsearch-serverless/api/transform/reset_transform.rb
+++ b/lib/elasticsearch-serverless/api/transform/reset_transform.rb
@@ -22,7 +22,9 @@ module ElasticsearchServerless
   module API
     module Transform
       module Actions
-        # Resets an existing transform.
+        # Resets a transform.
+        # Before you can reset it, you must stop it; alternatively, use the `force` query parameter.
+        # If the destination index was created by the transform, it is deleted.
         #
         # @option arguments [String] :transform_id Identifier for the transform. This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It has a 64 character limit and must start and end with alphanumeric characters. (*Required*)
         # @option arguments [Boolean] :force If this value is +true+, the transform is reset regardless of its current state. If it's +false+, the transform must be stopped before it can be reset.

--- a/lib/elasticsearch-serverless/api/transform/reset_transform.rb
+++ b/lib/elasticsearch-serverless/api/transform/reset_transform.rb
@@ -23,7 +23,7 @@ module ElasticsearchServerless
     module Transform
       module Actions
         # Resets a transform.
-        # Before you can reset it, you must stop it; alternatively, use the `force` query parameter.
+        # Before you can reset it, you must stop it; alternatively, use the +force+ query parameter.
         # If the destination index was created by the transform, it is deleted.
         #
         # @option arguments [String] :transform_id Identifier for the transform. This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It has a 64 character limit and must start and end with alphanumeric characters. (*Required*)

--- a/lib/elasticsearch-serverless/api/transform/schedule_now_transform.rb
+++ b/lib/elasticsearch-serverless/api/transform/schedule_now_transform.rb
@@ -24,6 +24,11 @@ module ElasticsearchServerless
       module Actions
         # Schedules now a transform.
         #
+        # If you _schedule_now a transform, it will process the new data instantly,
+        # without waiting for the configured frequency interval. After _schedule_now API is called,
+        # the transform will be processed again at now + frequency unless _schedule_now API
+        # is called again in the meantime.
+        #
         # @option arguments [String] :transform_id Identifier for the transform. (*Required*)
         # @option arguments [Time] :timeout Controls the time to wait for the scheduling to take place Server default: 30s.
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/transform/start_transform.rb
+++ b/lib/elasticsearch-serverless/api/transform/start_transform.rb
@@ -22,7 +22,22 @@ module ElasticsearchServerless
   module API
     module Transform
       module Actions
-        # Starts one or more transforms.
+        # Starts a transform.
+        #
+        # When you start a transform, it creates the destination index if it does not already exist. The `number_of_shards` is
+        # set to `1` and the `auto_expand_replicas` is set to `0-1`. If it is a pivot transform, it deduces the mapping
+        # definitions for the destination index from the source indices and the transform aggregations. If fields in the
+        # destination index are derived from scripts (as in the case of `scripted_metric` or `bucket_script` aggregations),
+        # the transform uses dynamic mappings unless an index template exists. If it is a latest transform, it does not deduce
+        # mapping definitions; it uses dynamic mappings. To use explicit mappings, create the destination index before you
+        # start the transform. Alternatively, you can create an index template, though it does not affect the deduced mappings
+        # in a pivot transform.
+        #
+        # When the transform starts, a series of validations occur to ensure its success. If you deferred validation when you
+        # created the transform, they occur when you start the transform—​with the exception of privilege checks. When
+        # Elasticsearch security features are enabled, the transform remembers which roles the user that created it had at the
+        # time of creation and uses those same roles. If those roles do not have the required privileges on the source and
+        # destination indices, the transform fails when it attempts unauthorized operations.
         #
         # @option arguments [String] :transform_id Identifier for the transform. (*Required*)
         # @option arguments [Time] :timeout Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error. Server default: 30s.

--- a/lib/elasticsearch-serverless/api/transform/start_transform.rb
+++ b/lib/elasticsearch-serverless/api/transform/start_transform.rb
@@ -24,10 +24,10 @@ module ElasticsearchServerless
       module Actions
         # Starts a transform.
         #
-        # When you start a transform, it creates the destination index if it does not already exist. The `number_of_shards` is
-        # set to `1` and the `auto_expand_replicas` is set to `0-1`. If it is a pivot transform, it deduces the mapping
+        # When you start a transform, it creates the destination index if it does not already exist. The +number_of_shards+ is
+        # set to +1+ and the +auto_expand_replicas+ is set to +0-1+. If it is a pivot transform, it deduces the mapping
         # definitions for the destination index from the source indices and the transform aggregations. If fields in the
-        # destination index are derived from scripts (as in the case of `scripted_metric` or `bucket_script` aggregations),
+        # destination index are derived from scripts (as in the case of +scripted_metric+ or +bucket_script+ aggregations),
         # the transform uses dynamic mappings unless an index template exists. If it is a latest transform, it does not deduce
         # mapping definitions; it uses dynamic mappings. To use explicit mappings, create the destination index before you
         # start the transform. Alternatively, you can create an index template, though it does not affect the deduced mappings

--- a/lib/elasticsearch-serverless/api/transform/update_transform.rb
+++ b/lib/elasticsearch-serverless/api/transform/update_transform.rb
@@ -24,9 +24,9 @@ module ElasticsearchServerless
       module Actions
         # Updates certain properties of a transform.
         #
-        # All updated properties except `description` do not take effect until after the transform starts the next checkpoint,
-        # thus there is data consistency in each checkpoint. To use this API, you must have `read` and `view_index_metadata`
-        # privileges for the source indices. You must also have `index` and `read` privileges for the destination index. When
+        # All updated properties except +description+ do not take effect until after the transform starts the next checkpoint,
+        # thus there is data consistency in each checkpoint. To use this API, you must have +read+ and +view_index_metadata+
+        # privileges for the source indices. You must also have +index+ and +read+ privileges for the destination index. When
         # Elasticsearch security features are enabled, the transform remembers which roles the user who updated it had at the
         # time of update and runs with those privileges.
         #

--- a/lib/elasticsearch-serverless/api/transform/update_transform.rb
+++ b/lib/elasticsearch-serverless/api/transform/update_transform.rb
@@ -24,6 +24,12 @@ module ElasticsearchServerless
       module Actions
         # Updates certain properties of a transform.
         #
+        # All updated properties except `description` do not take effect until after the transform starts the next checkpoint,
+        # thus there is data consistency in each checkpoint. To use this API, you must have `read` and `view_index_metadata`
+        # privileges for the source indices. You must also have `index` and `read` privileges for the destination index. When
+        # Elasticsearch security features are enabled, the transform remembers which roles the user who updated it had at the
+        # time of update and runs with those privileges.
+        #
         # @option arguments [String] :transform_id Identifier for the transform. (*Required*)
         # @option arguments [Boolean] :defer_validation When true, deferrable validations are not run. This behavior may be desired if the source index does not exist until after the transform is created.
         # @option arguments [Time] :timeout Period to wait for a response. If no response is received before the timeout expires, the request fails and returns an error. Server default: 30s.

--- a/lib/elasticsearch-serverless/api/update_by_query.rb
+++ b/lib/elasticsearch-serverless/api/update_by_query.rb
@@ -21,8 +21,8 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Performs an update on every document in the index without changing the source,
-      # for example to pick up a mapping change.
+      # Updates documents that match the specified query.
+      # If no query is specified, performs an update on every document in the data stream or index without modifying the source, which is useful for picking up mapping changes.
       #
       # @option arguments [String, Array] :index Comma-separated list of data streams, indices, and aliases to search. Supports wildcards (+*+). To search all data streams or indices, omit this parameter or use +*+ or +_all+. (*Required*)
       # @option arguments [Boolean] :allow_no_indices If +false+, the request returns an error if any wildcard expression, index alias, or +_all+ value targets only missing or closed indices. This behavior applies even if the request targets other open indices. For example, a request targeting +foo*,bar*+ returns an error if an index starts with +foo+ but no index starts with +bar+. Server default: true.


### PR DESCRIPTION
- Extends API source code docs based on specification.
- Updates generated source doc for correct YARD formatting 
- Updates README, client docs, yard in gitignore 

**API changes**

* `create` -  Adds [Integer, String] parameter `:wait_for_active_shards`: The number of shard copies that must be active before proceeding with the operation. Set to +all+ or any positive integer up to the total number of shards in the index (+number_of_replicas+1+). Server default: 1.
* `field_caps` - Adds boolean parameter `:include_empty_fields`: If false, empty fields are not included in the response. Server default: true.
* `get`, `mget`, `search` - Add boolean parameter `:force_synthetic_source`: Should this request force synthetic _source? Use this to test if the mapping supports synthetic _source and to get a sense of the worst case performance. Fetches with this enabled will be slower the enabling synthetic source natively in the index.
* `ml.get_trained_models` - Adds [String, Array] parameter `:model_id`: The unique identifier of the trained model or a model alias.  You can get information for multiple trained models in a single API request by using a comma-separated list of model IDs or a wildcard expression.
* `ml.put_calendar_job` Adds [String, Array] parameter `:job_id`: An identifier for the anomaly detection jobs. It can be a job identifier, a group name, or a comma-separated list of jobs or groups. (*Required*)
* `ml.put_trained_model` - Adds boolean parameter `:wait_for_completion`: Whether to wait for all child operations (e.g. model download) to complete.
* `search_application.search` - Adds boolean parameter `:typed_keys`: Determines whether aggregation names are prefixed by their respective types in the response.
* `security.get_api_key` - Adds boolean parameter `:active_only` A boolean flag that can be used to query API keys that are currently active. An API key is considered active if it is neither invalidated, nor expired at query time. You can specify this together with other parameters such as `owner` or `name`. If `active_only` is false, the response will include both active and inactive (expired or invalidated) keys. Adds boolean parameter `:with_profile_uid`: Determines whether to also retrieve the profile uid, for the API key owner principal, if it exists.
* `security.query_api_keys` - Adds boolean parameter `:with_profile_uid`: Determines whether to also retrieve the profile uid, for the API key owner principal, if it exists. Adds boolean parameter `:typed_keys`: Determines whether aggregation names are prefixed by their respective types in the response.