### PR TITLE
[API] Updates source code documentation.

### DIFF
--- a/lib/elasticsearch-serverless/api/bulk.rb
+++ b/lib/elasticsearch-serverless/api/bulk.rb
@@ -26,6 +26,7 @@ module ElasticsearchServerless
       # This reduces overhead and can greatly increase indexing speed.
       #
       # @option arguments [String] :index Name of the data stream, index, or index alias to perform bulk actions on.
+      # @option arguments [Boolean] :list_executed_pipelines If +true+, the response will include the ingest pipelines that were executed for each index or create.
       # @option arguments [String] :pipeline ID of the pipeline to use to preprocess incoming documents.
       #  If the index has a default ingest pipeline specified, then setting the value to +_none+ disables the default ingest pipeline for this request.
       #  If a final pipeline is configured it will always run, regardless of the value of this parameter.
@@ -39,6 +40,7 @@ module ElasticsearchServerless
       # @option arguments [Integer, String] :wait_for_active_shards The number of shard copies that must be active before proceeding with the operation.
       #  Set to all or any positive integer up to the total number of shards in the index (+number_of_replicas+1+). Server default: 1.
       # @option arguments [Boolean] :require_alias If +true+, the request’s actions must target an index alias.
+      # @option arguments [Boolean] :require_data_stream If +true+, the request's actions must target a data stream (existing or to-be-created).
       # @option arguments [Hash] :headers Custom HTTP headers
       # @option arguments [String|Array] :body operations. Array of Strings, Header/Data pairs, or the conveniency "combined" format can be passed, refer to ElasticsearchServerless::API::Utils.bulkify documentation.
       #

--- a/lib/elasticsearch-serverless/api/cat/aliases.rb
+++ b/lib/elasticsearch-serverless/api/cat/aliases.rb
@@ -29,12 +29,12 @@ module ElasticsearchServerless
         #
         # @option arguments [String, Array<String>] :name A comma-separated list of aliases to retrieve. Supports wildcards (+*+).  To retrieve all aliases, omit this parameter or use +*+ or +_all+.
         # @option arguments [String, Array<String>] :expand_wildcards Whether to expand wildcard expression to concrete indices that are open, closed or both.
+        # @option arguments [Time] :master_timeout Period to wait for a connection to the master node. Server default: 30s.
         # @option arguments [String] :format Specifies the format to return the columnar data in, can be set to
         #  +text+, +json+, +cbor+, +yaml+, or +smile+. Server default: text.
         # @option arguments [String, Array<String>] :h List of columns to appear in the response. Supports simple wildcards.
         # @option arguments [Boolean] :help When set to +true+ will output available columns. This option
         #  can't be combined with any other query string option.
-        # @option arguments [Time] :master_timeout Period to wait for a connection to the master node. Server default: 30s.
         # @option arguments [String, Array<String>] :s List of columns that determine how the table should be sorted.
         #  Sorting defaults to ascending and can be changed by setting +:asc+
         #  or +:desc+ as a suffix to the column name.

--- a/lib/elasticsearch-serverless/api/cat/component_templates.rb
+++ b/lib/elasticsearch-serverless/api/cat/component_templates.rb
@@ -33,12 +33,12 @@ module ElasticsearchServerless
         #  local cluster state. If +false+ the list of selected nodes are computed
         #  from the cluster state of the master node. In both cases the coordinating
         #  node will send requests for further information to each selected node.
+        # @option arguments [Time] :master_timeout Period to wait for a connection to the master node. Server default: 30s.
         # @option arguments [String] :format Specifies the format to return the columnar data in, can be set to
         #  +text+, +json+, +cbor+, +yaml+, or +smile+. Server default: text.
         # @option arguments [String, Array<String>] :h List of columns to appear in the response. Supports simple wildcards.
         # @option arguments [Boolean] :help When set to +true+ will output available columns. This option
         #  can't be combined with any other query string option.
-        # @option arguments [Time] :master_timeout Period to wait for a connection to the master node. Server default: 30s.
         # @option arguments [String, Array<String>] :s List of columns that determine how the table should be sorted.
         #  Sorting defaults to ascending and can be changed by setting +:asc+
         #  or +:desc+ as a suffix to the column name.

--- a/lib/elasticsearch-serverless/api/cat/count.rb
+++ b/lib/elasticsearch-serverless/api/cat/count.rb
@@ -35,7 +35,6 @@ module ElasticsearchServerless
         # @option arguments [String, Array<String>] :h List of columns to appear in the response. Supports simple wildcards.
         # @option arguments [Boolean] :help When set to +true+ will output available columns. This option
         #  can't be combined with any other query string option.
-        # @option arguments [Time] :master_timeout Period to wait for a connection to the master node. Server default: 30s.
         # @option arguments [String, Array<String>] :s List of columns that determine how the table should be sorted.
         #  Sorting defaults to ascending and can be changed by setting +:asc+
         #  or +:desc+ as a suffix to the column name.

--- a/lib/elasticsearch-serverless/api/cat/help.rb
+++ b/lib/elasticsearch-serverless/api/cat/help.rb
@@ -25,16 +25,6 @@ module ElasticsearchServerless
         # Get CAT help.
         # Returns help for the CAT APIs.
         #
-        # @option arguments [String] :format Specifies the format to return the columnar data in, can be set to
-        #  +text+, +json+, +cbor+, +yaml+, or +smile+. Server default: text.
-        # @option arguments [String, Array<String>] :h List of columns to appear in the response. Supports simple wildcards.
-        # @option arguments [Boolean] :help When set to +true+ will output available columns. This option
-        #  can't be combined with any other query string option.
-        # @option arguments [Time] :master_timeout Period to wait for a connection to the master node. Server default: 30s.
-        # @option arguments [String, Array<String>] :s List of columns that determine how the table should be sorted.
-        #  Sorting defaults to ascending and can be changed by setting +:asc+
-        #  or +:desc+ as a suffix to the column name.
-        # @option arguments [Boolean] :v When set to +true+ will enable verbose output.
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/cat.html
@@ -49,7 +39,7 @@ module ElasticsearchServerless
 
           method = ElasticsearchServerless::API::HTTP_GET
           path   = "_cat"
-          params = Utils.process_params(arguments)
+          params = {}
 
           ElasticsearchServerless::API::Response.new(
             perform_request(method, path, params, body, headers, request_opts)

--- a/lib/elasticsearch-serverless/api/cat/indices.rb
+++ b/lib/elasticsearch-serverless/api/cat/indices.rb
@@ -43,12 +43,12 @@ module ElasticsearchServerless
         # @option arguments [Boolean] :include_unloaded_segments If true, the response includes information from segments that are not loaded into memory.
         # @option arguments [Boolean] :pri If true, the response only includes information from primary shards.
         # @option arguments [String] :time The unit used to display time values.
+        # @option arguments [Time] :master_timeout Period to wait for a connection to the master node. Server default: 30s.
         # @option arguments [String] :format Specifies the format to return the columnar data in, can be set to
         #  +text+, +json+, +cbor+, +yaml+, or +smile+. Server default: text.
         # @option arguments [String, Array<String>] :h List of columns to appear in the response. Supports simple wildcards.
         # @option arguments [Boolean] :help When set to +true+ will output available columns. This option
         #  can't be combined with any other query string option.
-        # @option arguments [Time] :master_timeout Period to wait for a connection to the master node. Server default: 30s.
         # @option arguments [String, Array<String>] :s List of columns that determine how the table should be sorted.
         #  Sorting defaults to ascending and can be changed by setting +:asc+
         #  or +:desc+ as a suffix to the column name.

--- a/lib/elasticsearch-serverless/api/cat/ml_data_frame_analytics.rb
+++ b/lib/elasticsearch-serverless/api/cat/ml_data_frame_analytics.rb
@@ -34,13 +34,12 @@ module ElasticsearchServerless
         # @option arguments [String, Array<String>] :h Comma-separated list of column names to display. Server default: create_time,id,state,type.
         # @option arguments [String, Array<String>] :s Comma-separated list of column names or column aliases used to sort the
         #  response.
-        # @option arguments [Time] :time Unit used to display time values.
+        # @option arguments [String] :time Unit used to display time values.
         # @option arguments [String] :format Specifies the format to return the columnar data in, can be set to
         #  +text+, +json+, +cbor+, +yaml+, or +smile+. Server default: text.
         # @option arguments [String, Array<String>] :h List of columns to appear in the response. Supports simple wildcards.
         # @option arguments [Boolean] :help When set to +true+ will output available columns. This option
         #  can't be combined with any other query string option.
-        # @option arguments [Time] :master_timeout Period to wait for a connection to the master node. Server default: 30s.
         # @option arguments [String, Array<String>] :s List of columns that determine how the table should be sorted.
         #  Sorting defaults to ascending and can be changed by setting +:asc+
         #  or +:desc+ as a suffix to the column name.

--- a/lib/elasticsearch-serverless/api/cat/ml_datafeeds.rb
+++ b/lib/elasticsearch-serverless/api/cat/ml_datafeeds.rb
@@ -47,7 +47,6 @@ module ElasticsearchServerless
         # @option arguments [String, Array<String>] :h List of columns to appear in the response. Supports simple wildcards.
         # @option arguments [Boolean] :help When set to +true+ will output available columns. This option
         #  can't be combined with any other query string option.
-        # @option arguments [Time] :master_timeout Period to wait for a connection to the master node. Server default: 30s.
         # @option arguments [String, Array<String>] :s List of columns that determine how the table should be sorted.
         #  Sorting defaults to ascending and can be changed by setting +:asc+
         #  or +:desc+ as a suffix to the column name.

--- a/lib/elasticsearch-serverless/api/cat/ml_jobs.rb
+++ b/lib/elasticsearch-serverless/api/cat/ml_jobs.rb
@@ -48,7 +48,6 @@ module ElasticsearchServerless
         # @option arguments [String, Array<String>] :h List of columns to appear in the response. Supports simple wildcards.
         # @option arguments [Boolean] :help When set to +true+ will output available columns. This option
         #  can't be combined with any other query string option.
-        # @option arguments [Time] :master_timeout Period to wait for a connection to the master node. Server default: 30s.
         # @option arguments [String, Array<String>] :s List of columns that determine how the table should be sorted.
         #  Sorting defaults to ascending and can be changed by setting +:asc+
         #  or +:desc+ as a suffix to the column name.

--- a/lib/elasticsearch-serverless/api/cat/ml_trained_models.rb
+++ b/lib/elasticsearch-serverless/api/cat/ml_trained_models.rb
@@ -37,12 +37,12 @@ module ElasticsearchServerless
         # @option arguments [String, Array<String>] :s A comma-separated list of column names or aliases used to sort the response.
         # @option arguments [Integer] :from Skips the specified number of transforms.
         # @option arguments [Integer] :size The maximum number of transforms to display.
+        # @option arguments [String] :time Unit used to display time values.
         # @option arguments [String] :format Specifies the format to return the columnar data in, can be set to
         #  +text+, +json+, +cbor+, +yaml+, or +smile+. Server default: text.
         # @option arguments [String, Array<String>] :h List of columns to appear in the response. Supports simple wildcards.
         # @option arguments [Boolean] :help When set to +true+ will output available columns. This option
         #  can't be combined with any other query string option.
-        # @option arguments [Time] :master_timeout Period to wait for a connection to the master node. Server default: 30s.
         # @option arguments [String, Array<String>] :s List of columns that determine how the table should be sorted.
         #  Sorting defaults to ascending and can be changed by setting +:asc+
         #  or +:desc+ as a suffix to the column name.

--- a/lib/elasticsearch-serverless/api/cat/transforms.rb
+++ b/lib/elasticsearch-serverless/api/cat/transforms.rb
@@ -22,8 +22,8 @@ module ElasticsearchServerless
   module API
     module Cat
       module Actions
-        # Get transforms.
-        # Returns configuration and usage information about transforms.
+        # Get transform information.
+        # Get configuration and usage information about transforms.
         # CAT APIs are only intended for human consumption using the Kibana
         # console or command line. They are not intended for use by applications. For
         # application consumption, use the get transform statistics API.
@@ -43,7 +43,6 @@ module ElasticsearchServerless
         # @option arguments [String, Array<String>] :h List of columns to appear in the response. Supports simple wildcards.
         # @option arguments [Boolean] :help When set to +true+ will output available columns. This option
         #  can't be combined with any other query string option.
-        # @option arguments [Time] :master_timeout Period to wait for a connection to the master node. Server default: 30s.
         # @option arguments [String, Array<String>] :s List of columns that determine how the table should be sorted.
         #  Sorting defaults to ascending and can be changed by setting +:asc+
         #  or +:desc+ as a suffix to the column name.

--- a/lib/elasticsearch-serverless/api/count.rb
+++ b/lib/elasticsearch-serverless/api/count.rb
@@ -21,7 +21,8 @@
 module ElasticsearchServerless
   module API
     module Actions
-      # Returns number of documents matching a query.
+      # Count search results.
+      # Get the number of documents matching a query.
       #
       # @option arguments [String, Array] :index Comma-separated list of data streams, indices, and aliases to search.
       #  Supports wildcards (+*+).

--- a/lib/elasticsearch-serverless/api/enrich/execute_policy.rb
+++ b/lib/elasticsearch-serverless/api/enrich/execute_policy.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module Enrich
       module Actions
-        # Creates the enrich index for an existing enrich policy.
+        # Run an enrich policy.
+        # Create the enrich index for an existing enrich policy.
         #
         # @option arguments [String] :name Enrich policy to execute. (*Required*)
         # @option arguments [Boolean] :wait_for_completion If +true+, the request blocks other enrich policy execution requests until complete. Server default: true.

--- a/lib/elasticsearch-serverless/api/eql/delete.rb
+++ b/lib/elasticsearch-serverless/api/eql/delete.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module Eql
       module Actions
-        # Deletes an async EQL search or a stored synchronous EQL search.
+        # Delete an async EQL search.
+        # Delete an async EQL search or a stored synchronous EQL search.
         # The API also deletes results for the search.
         #
         # @option arguments [String] :id Identifier for the search to delete.

--- a/lib/elasticsearch-serverless/api/eql/get.rb
+++ b/lib/elasticsearch-serverless/api/eql/get.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module Eql
       module Actions
-        # Returns the current status and available results for an async EQL search or a stored synchronous EQL search.
+        # Get async EQL search results.
+        # Get the current status and available results for an async EQL search or a stored synchronous EQL search.
         #
         # @option arguments [String] :id Identifier for the search. (*Required*)
         # @option arguments [Time] :keep_alive Period for which the search and its results are stored on the cluster.

--- a/lib/elasticsearch-serverless/api/eql/get_status.rb
+++ b/lib/elasticsearch-serverless/api/eql/get_status.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module Eql
       module Actions
-        # Returns the current status for an async EQL search or a stored synchronous EQL search without returning results.
+        # Get the async EQL status.
+        # Get the current status for an async EQL search or a stored synchronous EQL search without returning results.
         #
         # @option arguments [String] :id Identifier for the search. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/eql/search.rb
+++ b/lib/elasticsearch-serverless/api/eql/search.rb
@@ -22,10 +22,15 @@ module ElasticsearchServerless
   module API
     module Eql
       module Actions
-        # Returns results matching a query expressed in Event Query Language (EQL)
+        # Get EQL search results.
+        # Returns search results for an Event Query Language (EQL) query.
+        # EQL assumes each document in a data stream or index corresponds to an event.
         #
         # @option arguments [String, Array] :index The name of the index to scope the operation (*Required*)
         # @option arguments [Boolean] :allow_no_indices [TODO] Server default: true.
+        # @option arguments [Boolean] :allow_partial_search_results If true, returns partial results if there are shard failures. If false, returns an error with no partial results.
+        # @option arguments [Boolean] :allow_partial_sequence_results If true, sequence queries will return partial results in case of shard failures. If false, they will return no results at all.
+        #  This flag has effect only if allow_partial_search_results is true.
         # @option arguments [String, Array<String>] :expand_wildcards [TODO] Server default: open.
         # @option arguments [Boolean] :ignore_unavailable If true, missing or closed indices are not included in the response. Server default: true.
         # @option arguments [Time] :keep_alive Period for which the search and its results are stored on the cluster. Server default: 5d.

--- a/lib/elasticsearch-serverless/api/graph/explore.rb
+++ b/lib/elasticsearch-serverless/api/graph/explore.rb
@@ -22,7 +22,12 @@ module ElasticsearchServerless
   module API
     module Graph
       module Actions
-        # Extracts and summarizes information about the documents and terms in an Elasticsearch data stream or index.
+        # Explore graph analytics.
+        # Extract and summarize information about the documents and terms in an Elasticsearch data stream or index.
+        # The easiest way to understand the behavior of this API is to use the Graph UI to explore connections.
+        # An initial request to the +_explore+ API contains a seed query that identifies the documents of interest and specifies the fields that define the vertices and connections you want to include in the graph.
+        # Subsequent requests enable you to spider out from one more vertices of interest.
+        # You can exclude vertices that have already been returned.
         #
         # @option arguments [String, Array] :index Name of the index. (*Required*)
         # @option arguments [String] :routing Custom value used to route operations to a specific shard.

--- a/lib/elasticsearch-serverless/api/indices/exists_alias.rb
+++ b/lib/elasticsearch-serverless/api/indices/exists_alias.rb
@@ -35,6 +35,8 @@ module ElasticsearchServerless
         #  Supports comma-separated values, such as +open,hidden+.
         #  Valid values are: +all+, +open+, +closed+, +hidden+, +none+. Server default: open.
         # @option arguments [Boolean] :ignore_unavailable If +false+, requests that include a missing data stream or index in the target indices or data streams return an error.
+        # @option arguments [Time] :master_timeout Period to wait for a connection to the master node.
+        #  If no response is received before the timeout expires, the request fails and returns an error. Server default: 30s.
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html

--- a/lib/elasticsearch-serverless/api/indices/exists_index_template.rb
+++ b/lib/elasticsearch-serverless/api/indices/exists_index_template.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Returns information about whether a particular index template exists.
+        # Check index templates.
+        # Check whether index templates exist.
         #
         # @option arguments [String] :name Comma-separated list of index template names used to limit the request. Wildcard (*) expressions are supported. (*Required*)
         # @option arguments [Time] :master_timeout Period to wait for a connection to the master node. If no response is received before the timeout expires, the request fails and returns an error. Server default: 30s.

--- a/lib/elasticsearch-serverless/api/indices/explain_data_lifecycle.rb
+++ b/lib/elasticsearch-serverless/api/indices/explain_data_lifecycle.rb
@@ -23,7 +23,7 @@ module ElasticsearchServerless
     module Indices
       module Actions
         # Get the status for a data stream lifecycle.
-        # Retrieves information about an index or data stream’s current data stream lifecycle status, such as time since index creation, time since rollover, the lifecycle configuration managing the index, or any errors encountered during lifecycle execution.
+        # Get information about an index or data stream's current data stream lifecycle status, such as time since index creation, time since rollover, the lifecycle configuration managing the index, or any errors encountered during lifecycle execution.
         #
         # @option arguments [String, Array] :index The name of the index to explain (*Required*)
         # @option arguments [Boolean] :include_defaults indicates if the API should return the default values the system uses for the index's lifecycle

--- a/lib/elasticsearch-serverless/api/indices/get_alias.rb
+++ b/lib/elasticsearch-serverless/api/indices/get_alias.rb
@@ -38,6 +38,8 @@ module ElasticsearchServerless
         #  Supports comma-separated values, such as +open,hidden+.
         #  Valid values are: +all+, +open+, +closed+, +hidden+, +none+. Server default: open.
         # @option arguments [Boolean] :ignore_unavailable If +false+, the request returns an error if it targets a missing or closed index.
+        # @option arguments [Time] :master_timeout Period to wait for a connection to the master node.
+        #  If no response is received before the timeout expires, the request fails and returns an error. Server default: 30s.
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html

--- a/lib/elasticsearch-serverless/api/indices/resolve_index.rb
+++ b/lib/elasticsearch-serverless/api/indices/resolve_index.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module Indices
       module Actions
-        # Resolves the specified name(s) and/or index patterns for indices, aliases, and data streams.
+        # Resolve indices.
+        # Resolve the names and/or index patterns for indices, aliases, and data streams.
         # Multiple patterns and remote clusters are supported.
         #
         # @option arguments [String, Array<String>] :name Comma-separated name(s) or index pattern(s) of the indices, aliases, and data streams to resolve.

--- a/lib/elasticsearch-serverless/api/inference/put.rb
+++ b/lib/elasticsearch-serverless/api/inference/put.rb
@@ -22,7 +22,15 @@ module ElasticsearchServerless
   module API
     module Inference
       module Actions
-        # Create an inference endpoint
+        # Create an inference endpoint.
+        # When you create an inference endpoint, the associated machine learning model is automatically deployed if it is not already running.
+        # After creating the endpoint, wait for the model deployment to complete before using it.
+        # To verify the deployment status, use the get trained model statistics API.
+        # Look for +"state": "fully_allocated"+ in the response and ensure that the +"allocation_count"+ matches the +"target_allocation_count"+.
+        # Avoid creating multiple endpoints for the same model unless required, as each endpoint consumes significant resources.
+        # IMPORTANT: The inference APIs enable you to use certain services, such as built-in machine learning models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, Mistral, Azure OpenAI, Google AI Studio, Google Vertex AI, Anthropic, Watsonx.ai, or Hugging Face.
+        # For built-in models and models uploaded through Eland, the inference APIs offer an alternative way to use and manage trained models.
+        # However, if you do not plan to use the inference APIs to use these models or if you want to use non-NLP models, use the machine learning trained model APIs.
         #
         # @option arguments [String] :task_type The task type
         # @option arguments [String] :inference_id The inference Id (*Required*)

--- a/lib/elasticsearch-serverless/api/ingest/delete_pipeline.rb
+++ b/lib/elasticsearch-serverless/api/ingest/delete_pipeline.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module Ingest
       module Actions
-        # Deletes one or more existing ingest pipeline.
+        # Delete pipelines.
+        # Delete one or more ingest pipelines.
         #
         # @option arguments [String] :id Pipeline ID or wildcard expression of pipeline IDs used to limit the request.
         #  To delete all ingest pipelines in a cluster, use a value of +*+. (*Required*)

--- a/lib/elasticsearch-serverless/api/ingest/get_pipeline.rb
+++ b/lib/elasticsearch-serverless/api/ingest/get_pipeline.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module Ingest
       module Actions
-        # Returns information about one or more ingest pipelines.
+        # Get pipelines.
+        # Get information about one or more ingest pipelines.
         # This API returns a local reference of the pipeline.
         #
         # @option arguments [String] :id Comma-separated list of pipeline IDs to retrieve.

--- a/lib/elasticsearch-serverless/api/ingest/processor_grok.rb
+++ b/lib/elasticsearch-serverless/api/ingest/processor_grok.rb
@@ -22,8 +22,9 @@ module ElasticsearchServerless
   module API
     module Ingest
       module Actions
-        # Extracts structured fields out of a single text field within a document.
-        # You choose which field to extract matched fields from, as well as the grok pattern you expect will match.
+        # Run a grok processor.
+        # Extract structured fields out of a single text field within a document.
+        # You must choose which field to extract matched fields from, as well as the grok pattern you expect will match.
         # A grok pattern is like a regular expression that supports aliased expressions that can be reused.
         #
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/ingest/put_pipeline.rb
+++ b/lib/elasticsearch-serverless/api/ingest/put_pipeline.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Ingest
       module Actions
-        # Creates or updates an ingest pipeline.
+        # Create or update a pipeline.
         # Changes made using this API take effect immediately.
         #
         # @option arguments [String] :id ID of the ingest pipeline to create or update. (*Required*)

--- a/lib/elasticsearch-serverless/api/ingest/simulate.rb
+++ b/lib/elasticsearch-serverless/api/ingest/simulate.rb
@@ -22,7 +22,9 @@ module ElasticsearchServerless
   module API
     module Ingest
       module Actions
-        # Executes an ingest pipeline against a set of provided documents.
+        # Simulate a pipeline.
+        # Run an ingest pipeline against a set of provided documents.
+        # You can either specify an existing pipeline to use with the provided documents or supply a pipeline definition in the body of the request.
         #
         # @option arguments [String] :id Pipeline to test.
         #  If you don’t specify a +pipeline+ in the request body, this parameter is required.

--- a/lib/elasticsearch-serverless/api/license/get.rb
+++ b/lib/elasticsearch-serverless/api/license/get.rb
@@ -23,8 +23,9 @@ module ElasticsearchServerless
     module License
       module Actions
         # Get license information.
-        # Returns information about your Elastic license, including its type, its status, when it was issued, and when it expires.
-        # For more information about the different types of licenses, refer to {https://www.elastic.co/subscriptions Elastic Stack subscriptions}.
+        # Get information about your Elastic license including its type, its status, when it was issued, and when it expires.
+        # NOTE: If the master node is generating a new cluster state, the get license API may return a +404 Not Found+ response.
+        # If you receive an unexpected 404 response after cluster startup, wait a short period and retry the request.
         #
         # @option arguments [Boolean] :accept_enterprise If +true+, this parameter returns enterprise for Enterprise license types. If +false+, this parameter returns platinum for both platinum and enterprise license types. This behavior is maintained for backwards compatibility.
         #  This parameter is deprecated and will always be set to true in 8.x. Server default: true.

--- a/lib/elasticsearch-serverless/api/logstash/delete_pipeline.rb
+++ b/lib/elasticsearch-serverless/api/logstash/delete_pipeline.rb
@@ -22,9 +22,10 @@ module ElasticsearchServerless
   module API
     module Logstash
       module Actions
-        # Deletes a pipeline used for Logstash Central Management.
+        # Delete a Logstash pipeline.
+        # Delete a pipeline that is used for Logstash Central Management.
         #
-        # @option arguments [String] :id Identifier for the pipeline. (*Required*)
+        # @option arguments [String] :id An identifier for the pipeline. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/logstash-api-delete-pipeline.html

--- a/lib/elasticsearch-serverless/api/logstash/get_pipeline.rb
+++ b/lib/elasticsearch-serverless/api/logstash/get_pipeline.rb
@@ -22,9 +22,10 @@ module ElasticsearchServerless
   module API
     module Logstash
       module Actions
-        # Retrieves pipelines used for Logstash Central Management.
+        # Get Logstash pipelines.
+        # Get pipelines that are used for Logstash Central Management.
         #
-        # @option arguments [String, Array] :id Comma-separated list of pipeline identifiers.
+        # @option arguments [String, Array] :id A comma-separated list of pipeline identifiers.
         # @option arguments [Hash] :headers Custom HTTP headers
         #
         # @see https://www.elastic.co/guide/en/elasticsearch/reference/current/logstash-api-get-pipeline.html

--- a/lib/elasticsearch-serverless/api/logstash/put_pipeline.rb
+++ b/lib/elasticsearch-serverless/api/logstash/put_pipeline.rb
@@ -22,9 +22,11 @@ module ElasticsearchServerless
   module API
     module Logstash
       module Actions
-        # Creates or updates a pipeline used for Logstash Central Management.
+        # Create or update a Logstash pipeline.
+        # Create a pipeline that is used for Logstash Central Management.
+        # If the specified pipeline exists, it is replaced.
         #
-        # @option arguments [String] :id Identifier for the pipeline. (*Required*)
+        # @option arguments [String] :id An identifier for the pipeline. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body pipeline
         #

--- a/lib/elasticsearch-serverless/api/machine_learning/get_trained_models.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/get_trained_models.rb
@@ -41,6 +41,7 @@ module ElasticsearchServerless
         # @option arguments [Integer] :from Skips the specified number of models. Server default: 0.
         # @option arguments [String] :include A comma delimited string of optional fields to include in the response
         #  body.
+        # @option arguments [Boolean] :include_model_definition parameter is deprecated! Use [include=definition] instead
         # @option arguments [Integer] :size Specifies the maximum number of models to obtain. Server default: 100.
         # @option arguments [String] :tags A comma delimited string of tags. A trained model can have many tags, or
         #  none. When supplied, only trained models that contain all the supplied

--- a/lib/elasticsearch-serverless/api/machine_learning/put_job.rb
+++ b/lib/elasticsearch-serverless/api/machine_learning/put_job.rb
@@ -26,6 +26,17 @@ module ElasticsearchServerless
         # If you include a +datafeed_config+, you must have read index privileges on the source index.
         #
         # @option arguments [String] :job_id The identifier for the anomaly detection job. This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric characters. (*Required*)
+        # @option arguments [Boolean] :allow_no_indices If +true+, wildcard indices expressions that resolve into no concrete indices are ignored. This includes the
+        #  +_all+ string or when no indices are specified. Server default: true.
+        # @option arguments [String, Array<String>] :expand_wildcards Type of index that wildcard patterns can match. If the request can target data streams, this argument determines
+        #  whether wildcard expressions match hidden data streams. Supports comma-separated values. Valid values are:
+        #  - +all+: Match any data stream or index, including hidden ones.
+        #  - +closed+: Match closed, non-hidden indices. Also matches any non-hidden data stream. Data streams cannot be closed.
+        #  - +hidden+: Match hidden data streams and hidden indices. Must be combined with +open+, +closed+, or both.
+        #  - +none+: Wildcard patterns are not accepted.
+        #  - +open+: Match open, non-hidden indices. Also matches any non-hidden data stream. Server default: open.
+        # @option arguments [Boolean] :ignore_throttled If +true+, concrete, expanded or aliased indices are ignored when frozen. Server default: true.
+        # @option arguments [Boolean] :ignore_unavailable If +true+, unavailable indices (missing or closed) are ignored.
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body request body
         #
@@ -52,7 +63,7 @@ module ElasticsearchServerless
 
           method = ElasticsearchServerless::API::HTTP_PUT
           path   = "_ml/anomaly_detectors/#{Utils.listify(_job_id)}"
-          params = {}
+          params = Utils.process_params(arguments)
 
           ElasticsearchServerless::API::Response.new(
             perform_request(method, path, params, body, headers, request_opts)

--- a/lib/elasticsearch-serverless/api/ping.rb
+++ b/lib/elasticsearch-serverless/api/ping.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Actions
       # Ping the cluster.
-      # Returns whether the cluster is running.
+      # Get information about whether the cluster is running.
       #
       # @option arguments [Hash] :headers Custom HTTP headers
       #

--- a/lib/elasticsearch-serverless/api/query_rules/delete_rule.rb
+++ b/lib/elasticsearch-serverless/api/query_rules/delete_rule.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module QueryRules
       module Actions
-        # Deletes a query rule within a query ruleset.
+        # Delete a query rule.
+        # Delete a query rule within a query ruleset.
         #
         # @option arguments [String] :ruleset_id The unique identifier of the query ruleset containing the rule to delete (*Required*)
         # @option arguments [String] :rule_id The unique identifier of the query rule within the specified ruleset to delete (*Required*)

--- a/lib/elasticsearch-serverless/api/query_rules/delete_ruleset.rb
+++ b/lib/elasticsearch-serverless/api/query_rules/delete_ruleset.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module QueryRules
       module Actions
-        # Deletes a query ruleset.
+        # Delete a query ruleset.
         #
         # @option arguments [String] :ruleset_id The unique identifier of the query ruleset to delete (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/query_rules/get_rule.rb
+++ b/lib/elasticsearch-serverless/api/query_rules/get_rule.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module QueryRules
       module Actions
-        # Returns the details about a query rule within a query ruleset
+        # Get a query rule.
+        # Get details about a query rule within a query ruleset.
         #
         # @option arguments [String] :ruleset_id The unique identifier of the query ruleset containing the rule to retrieve (*Required*)
         # @option arguments [String] :rule_id The unique identifier of the query rule within the specified ruleset to retrieve (*Required*)

--- a/lib/elasticsearch-serverless/api/query_rules/get_ruleset.rb
+++ b/lib/elasticsearch-serverless/api/query_rules/get_ruleset.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module QueryRules
       module Actions
-        # Returns the details about a query ruleset
+        # Get a query ruleset.
+        # Get details about a query ruleset.
         #
         # @option arguments [String] :ruleset_id The unique identifier of the query ruleset (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/query_rules/list_rulesets.rb
+++ b/lib/elasticsearch-serverless/api/query_rules/list_rulesets.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module QueryRules
       module Actions
-        # Returns summarized information about existing query rulesets.
+        # Get all query rulesets.
+        # Get summarized information about the query rulesets.
         #
         # @option arguments [Integer] :from Starting offset (default: 0)
         # @option arguments [Integer] :size specifies a max number of results to get

--- a/lib/elasticsearch-serverless/api/query_rules/put_rule.rb
+++ b/lib/elasticsearch-serverless/api/query_rules/put_rule.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module QueryRules
       module Actions
-        # Creates or updates a query rule within a query ruleset.
+        # Create or update a query rule.
+        # Create or update a query rule within a query ruleset.
         #
         # @option arguments [String] :ruleset_id The unique identifier of the query ruleset containing the rule to be created or updated (*Required*)
         # @option arguments [String] :rule_id The unique identifier of the query rule within the specified ruleset to be created or updated (*Required*)

--- a/lib/elasticsearch-serverless/api/query_rules/put_ruleset.rb
+++ b/lib/elasticsearch-serverless/api/query_rules/put_ruleset.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module QueryRules
       module Actions
-        # Creates or updates a query ruleset.
+        # Create or update a query ruleset.
         #
         # @option arguments [String] :ruleset_id The unique identifier of the query ruleset to be created or updated (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/query_rules/test.rb
+++ b/lib/elasticsearch-serverless/api/query_rules/test.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module QueryRules
       module Actions
-        # Creates or updates a query ruleset.
+        # Test a query ruleset.
+        # Evaluate match criteria against a query ruleset to identify the rules that would match that criteria.
         #
         # @option arguments [String] :ruleset_id The unique identifier of the query ruleset to be created or updated (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/sql/clear_cursor.rb
+++ b/lib/elasticsearch-serverless/api/sql/clear_cursor.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module SQL
       module Actions
-        # Clears the SQL cursor
+        # Clear an SQL search cursor.
         #
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body request body

--- a/lib/elasticsearch-serverless/api/sql/delete_async.rb
+++ b/lib/elasticsearch-serverless/api/sql/delete_async.rb
@@ -22,7 +22,9 @@ module ElasticsearchServerless
   module API
     module SQL
       module Actions
-        # Deletes an async SQL search or a stored synchronous SQL search. If the search is still running, the API cancels it.
+        # Delete an async SQL search.
+        # Delete an async SQL search or a stored synchronous SQL search.
+        # If the search is still running, the API cancels it.
         #
         # @option arguments [String] :id Identifier for the search. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/sql/get_async.rb
+++ b/lib/elasticsearch-serverless/api/sql/get_async.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module SQL
       module Actions
-        # Returns the current status and available results for an async SQL search or stored synchronous SQL search
+        # Get async SQL search results.
+        # Get the current status and available results for an async SQL search or stored synchronous SQL search.
         #
         # @option arguments [String] :id Identifier for the search. (*Required*)
         # @option arguments [String] :delimiter Separator for CSV results. The API only supports this parameter for CSV responses. Server default: ,.

--- a/lib/elasticsearch-serverless/api/sql/get_async_status.rb
+++ b/lib/elasticsearch-serverless/api/sql/get_async_status.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module SQL
       module Actions
-        # Returns the current status of an async SQL search or a stored synchronous SQL search
+        # Get the async SQL search status.
+        # Get the current status of an async SQL search or a stored synchronous SQL search.
         #
         # @option arguments [String] :id Identifier for the search. (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/sql/query.rb
+++ b/lib/elasticsearch-serverless/api/sql/query.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module SQL
       module Actions
-        # Executes a SQL request
+        # Get SQL search results.
+        # Run an SQL request.
         #
         # @option arguments [String] :format Format for the response.
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/sql/translate.rb
+++ b/lib/elasticsearch-serverless/api/sql/translate.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module SQL
       module Actions
-        # Translates SQL into Elasticsearch queries
+        # Translate SQL into Elasticsearch queries.
+        # Translate an SQL search into a search API request containing Query DSL.
         #
         # @option arguments [Hash] :headers Custom HTTP headers
         # @option arguments [Hash] :body request body

--- a/lib/elasticsearch-serverless/api/synonyms/delete_synonym.rb
+++ b/lib/elasticsearch-serverless/api/synonyms/delete_synonym.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Synonyms
       module Actions
-        # Deletes a synonym set
+        # Delete a synonym set.
         #
         # @option arguments [String] :id The id of the synonyms set to be deleted (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/synonyms/delete_synonym_rule.rb
+++ b/lib/elasticsearch-serverless/api/synonyms/delete_synonym_rule.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module Synonyms
       module Actions
-        # Deletes a synonym rule in a synonym set
+        # Delete a synonym rule.
+        # Delete a synonym rule from a synonym set.
         #
         # @option arguments [String] :set_id The id of the synonym set to be updated (*Required*)
         # @option arguments [String] :rule_id The id of the synonym rule to be deleted (*Required*)

--- a/lib/elasticsearch-serverless/api/synonyms/get_synonym.rb
+++ b/lib/elasticsearch-serverless/api/synonyms/get_synonym.rb
@@ -22,7 +22,7 @@ module ElasticsearchServerless
   module API
     module Synonyms
       module Actions
-        # Retrieves a synonym set
+        # Get a synonym set.
         #
         # @option arguments [String] :id "The id of the synonyms set to be retrieved (*Required*)
         # @option arguments [Integer] :from Starting offset for query rules to be retrieved Server default: 0.

--- a/lib/elasticsearch-serverless/api/synonyms/get_synonym_rule.rb
+++ b/lib/elasticsearch-serverless/api/synonyms/get_synonym_rule.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module Synonyms
       module Actions
-        # Retrieves a synonym rule from a synonym set
+        # Get a synonym rule.
+        # Get a synonym rule from a synonym set.
         #
         # @option arguments [String] :set_id The id of the synonym set to retrieve the synonym rule from (*Required*)
         # @option arguments [String] :rule_id The id of the synonym rule to retrieve (*Required*)

--- a/lib/elasticsearch-serverless/api/synonyms/get_synonyms_sets.rb
+++ b/lib/elasticsearch-serverless/api/synonyms/get_synonyms_sets.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module Synonyms
       module Actions
-        # Retrieves a summary of all defined synonym sets
+        # Get all synonym sets.
+        # Get a summary of all defined synonym sets.
         #
         # @option arguments [Integer] :from Starting offset Server default: 0.
         # @option arguments [Integer] :size specifies a max number of results to get Server default: 10.

--- a/lib/elasticsearch-serverless/api/synonyms/put_synonym.rb
+++ b/lib/elasticsearch-serverless/api/synonyms/put_synonym.rb
@@ -22,7 +22,9 @@ module ElasticsearchServerless
   module API
     module Synonyms
       module Actions
-        # Creates or updates a synonym set.
+        # Create or update a synonym set.
+        # Synonyms sets are limited to a maximum of 10,000 synonym rules per set.
+        # If you need to manage more synonym rules, you can create multiple synonym sets.
         #
         # @option arguments [String] :id The id of the synonyms set to be created or updated (*Required*)
         # @option arguments [Hash] :headers Custom HTTP headers

--- a/lib/elasticsearch-serverless/api/synonyms/put_synonym_rule.rb
+++ b/lib/elasticsearch-serverless/api/synonyms/put_synonym_rule.rb
@@ -22,7 +22,8 @@ module ElasticsearchServerless
   module API
     module Synonyms
       module Actions
-        # Creates or updates a synonym rule in a synonym set
+        # Create or update a synonym rule.
+        # Create or update a synonym rule in a synonym set.
         #
         # @option arguments [String] :set_id The id of the synonym set to be updated with the synonym rule (*Required*)
         # @option arguments [String] :rule_id The id of the synonym rule to be updated or created (*Required*)

--- a/lib/elasticsearch-serverless/api/tasks/get.rb
+++ b/lib/elasticsearch-serverless/api/tasks/get.rb
@@ -23,7 +23,7 @@ module ElasticsearchServerless
     module Tasks
       module Actions
         # Get task information.
-        # Returns information about the tasks currently executing in the cluster.
+        # Get information about a task currently running in the cluster.
         # This functionality is Experimental and may be changed or removed
         # completely in a future release. Elastic will take a best effort approach
         # to fix any issues, but experimental features are not subject to the


### PR DESCRIPTION
Updates APIs:
* bulk:
  - adds list_executed_pipelines - If +true+, the response will include the ingest pipelines that were executed for each index or create.
  - require_data_stream If +true+, the request's actions must target a data stream (existing or to-be-created).
* cat APIs have been streamlined, removes master_timeout, verbose options for Serverless.
* eql.search - Adds allow_partial_search_results and allow_partial_sequence_results parameters.
* indices.exists_alias, indices.get_alias - adds master_timeout parameter
* machine_learning.get_trained_models - include_model_definition parameter is deprecated! Use [include=definition] instead
* machine_learning.put_job - adds allow_no_indices, expand_wildcards, ignore_throttled and ignore_unavailable parameters