### PR TITLE
Update - 0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.7.0
+
+> [!WARNING]
+> Starting with the release of the Elastic Stack 9.0.0, this client will be discontinued. Instead, you can use the latest version of the [Elasticsearch Client](https://github.com/elastic/elasticsearch-ruby) to build your Elasticsearch Serverless Ruby applications.
+
+### Client
+
+- Adds testing for Ruby 3.4.
+
+### Changes in APIs:
+
+* `async_search.submit` - Removes `keep_alive` and `pre_filter_shard_size` parameters.
+* New API: `security.query_role`: Find roles with a query.
+* Source code documentation is updated.
+* `bulk`:
+  * Adds `list_executed_pipelines` - If `true`, the response will include the ingest pipelines that were executed for each index or create.
+  * Adds `require_data_stream` If `true`, the request's actions must target a data stream (existing or to-be-created).
+* `cat` APIs have been streamlined, `master_timeout` and `verbose` parameters removed in some endpoints.
+* `eql.search` - Adds `allow_partial_search_results` and `allow_partial_sequence_results` parameters.
+* `indices.exists_alias`, `indices.get_alias` - add `master_timeout` parameter.
+* `machine_learning.get_trained_models` - `include_model_definition` parameter is deprecated. Use `[include=definition]` instead.
+* `machine_learning.put_job` - adds `allow_no_indices`, `expand_wildcards`, `ignore_throttled` and `ignore_unavailable` parameters.
+
 ## 0.6.0
 
 ### Changes in APIs:

--- a/elasticsearch-serverless.gemspec
+++ b/elasticsearch-serverless.gemspec
@@ -28,4 +28,11 @@ Gem::Specification.new do |s|
   s.license     = 'Apache-2.0'
 
   s.add_dependency 'elastic-transport', '~> 8.3'
+  s.post_install_message = <<~EOM
+
+  WARNING: Starting with the release of the Elastic Stack 9.0.0, this client elasticsearch-serverless will be discontinued.
+  Instead, you can use the latest version of the Elasticsearch Client to build your Elasticsearch Serverless Ruby applications:
+  https://github.com/elastic/elasticsearch-ruby
+
+  EOM
 end

--- a/lib/elasticsearch-serverless.rb
+++ b/lib/elasticsearch-serverless.rb
@@ -26,6 +26,12 @@ module ElasticsearchServerless
     VALID_PARAMETERS = [:adapter, :log, :logger, :serializer_class, :trace, :tracer, :headers,
                         :request_timeout, :retry_on_status, :retry_on_failure, :delay_on_retry,
                         :opentelemetry_tracer_provider]
+    DEPRECATION_MESSAGE =
+      'WARNING: Starting with the release of the Elastic Stack 9.0.0, this client ' \
+      'will be discontinued.' \
+      'Instead, you can use the latest version of the Elasticsearch Client to build your ' \
+      'Elasticsearch Serverless Ruby applications: ' \
+      "https://github.com/elastic/elasticsearch-ruby\n".freeze
 
     # Initializes an Elasticsearch Serverless Client
     #
@@ -52,6 +58,7 @@ module ElasticsearchServerless
       validate_arguments(arguments)
       arguments.merge!(essential_parameters(url, api_key))
       @transport = Elastic::Transport::Client.new(arguments)
+      warn(DEPRECATION_MESSAGE)
     end
 
     def essential_parameters(url, api_key)

--- a/lib/elasticsearch-serverless/api.rb
+++ b/lib/elasticsearch-serverless/api.rb
@@ -53,32 +53,29 @@ module ElasticsearchServerless
       end
     end
 
-    # Add new namespaces to this constant
-    #
-    API_NAMESPACES = [
-      :async_search,
-      :cat,
-      :cluster,
-      :connector,
-      :enrich,
-      :eql,
-      :graph,
-      :indices,
-      :inference,
-      :ingest,
-      :license,
-      :logstash,
-      :machine_learning,
-      :query_rules,
-      :search_application,
-      :security,
-      :sql,
-      :synonyms,
-      :tasks,
-      :transform
-    ].freeze
-    UPPERCASE_APIS = ['sql'].freeze
+    # New namespaces are added dynamically with the Generator
+    API_NAMESPACES = [:async_search,
+                      :cat,
+                      :cluster,
+                      :connector,
+                      :enrich,
+                      :eql,
+                      :graph,
+                      :indices,
+                      :inference,
+                      :ingest,
+                      :license,
+                      :logstash,
+                      :machine_learning,
+                      :query_rules,
+                      :search_application,
+                      :security,
+                      :sql,
+                      :synonyms,
+                      :tasks,
+                      :transform].freeze
 
+    UPPERCASE_APIS = ['sql'].freeze
     API_NAMESPACES.each do |namespace|
       name = namespace.to_s
       module_name = if UPPERCASE_APIS.include?(name)

--- a/lib/elasticsearch-serverless/version.rb
+++ b/lib/elasticsearch-serverless/version.rb
@@ -17,6 +17,6 @@
 
 module ElasticsearchServerless
   API_VERSION = '2023-10-31'.freeze
-  CLIENT_VERSION = '0.6.0'.freeze
+  CLIENT_VERSION = '0.7.0'.freeze
   VERSION = CLIENT_VERSION
 end


### PR DESCRIPTION
> [!WARNING]
> Starting with the release of the Elastic Stack 9.0.0, this client will be discontinued. Instead, you can use the latest version of the [Elasticsearch Client](https://github.com/elastic/elasticsearch-ruby) to build your Elasticsearch Serverless Ruby applications.

The gem will now emit a warning when installing and the client will emit the warning when instantiating.